### PR TITLE
Sqlite backend for restbase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+test_db
+coverage/
+.coveralls.yml
+node_modules
+npm-debug.log
+.tern-project
+.tern-port
+*~
+.idea/*

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,4 @@
+node_modules
+test
+scripts
+coverage

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,32 @@
+{
+	"predef": [
+		"setImmediate",
+		"Map",
+		"Set"
+	],
+
+	"bitwise": true,
+	"laxbreak": true,
+	"curly": true,
+	"eqeqeq": true,
+	"immed": true,
+	"latedef": "nofunc",
+	"newcap": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"regexp": false,
+	"undef": true,
+	"strict": true,
+	"trailing": true,
+
+	"smarttabs": true,
+	"multistr": true,
+
+	"node": true,
+
+	"nomen": false,
+	"loopfunc": true,
+        "esnext": true
+	//"onevar": true
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,206 @@
+"use strict";
+/*
+ * SQLite-backed table storage service
+ */
+
+// global includes
+var spec = require('restbase-mod-table-spec').spec;
+var P    = require('bluebird');
+
+function RBSQLite(options) {
+    this.options = options;
+    this.conf = options.conf;
+    this.log = options.log;
+    this.setup = this.setup.bind(this);
+    this.store = null;
+    this.handler = {
+        spec: spec,
+        operations: {
+            createTable: this.createTable.bind(this),
+            dropTable: this.dropTable.bind(this),
+            getTableSchema: this.getTableSchema.bind(this),
+            get: this.get.bind(this),
+            put: this.put.bind(this)
+        }
+    };
+}
+
+RBSQLite.prototype.createTable = function(rb, req) {
+    var self = this;
+    var store = this.store;
+
+    req.body.table = req.params.table;
+    var domain = req.params.domain;
+
+    // check if the domains table exists
+    return store.createTable(domain, req.body)
+    .then(function() {
+        return {
+            status: 201, // created
+            body: {
+                type: 'table_created',
+                title: 'Table was created.',
+                domain: req.params.domain,
+                table: req.params.table
+            }
+        };
+    })
+    .catch(function(e) {
+        self.log('sqlite/error', e);
+        if (e.status >= 400) {
+            return {
+                status: e.status,
+                body: e.body
+            };
+        }
+        return {
+            status: 500,
+            body: {
+                type: 'table_creation_error',
+                title: 'Internal error while creating a table within the cassandra storage backend',
+                stack: e.stack,
+                err: e,
+                req: req
+            }
+        };
+    });
+};
+
+// Query a table
+RBSQLite.prototype.get = function(rb, req) {
+    var self = this;
+    var rp = req.params;
+    if (!rp.rest && !req.body) {
+        req.body = {
+            table: rp.table,
+            limit: 10
+        };
+    }
+    var domain = req.params.domain;
+    return this.store.get(domain, req.body)
+    .then(function(res) {
+        return {
+            status: res.items.length ? 200 : 404,
+            body: res
+        };
+    })
+    .catch(function(e) {
+        self.log('sqlite/error', e);
+        return {
+            status: 500,
+            body: {
+                type: 'query_error',
+                title: 'Error in Cassandra table storage backend',
+                stack: e.stack,
+                err: e,
+                req: req
+            }
+        };
+    });
+};
+
+// Update a table
+RBSQLite.prototype.put = function(rb, req) {
+    var self = this;
+    var domain = req.params.domain;
+    return this.store.put(domain, req.body)
+    .then(function() {
+        return {
+            status: 201 // created
+        };
+    })
+    .catch(function(e) {
+        self.log('sqlite/error', e);
+        return {
+            status: 500,
+            body: {
+                type: 'update_error',
+                title: 'Internal error in Cassandra table storage backend',
+                stack: e.stack,
+                err: e,
+                req: req
+            }
+        };
+    });
+};
+
+RBSQLite.prototype.dropTable = function(rb, req) {
+    var self = this;
+    var domain = req.params.domain;
+    return this.store.dropTable(domain, req.params.table)
+    .then(function() {
+        return {
+            status: 204 // done
+        };
+    })
+    .catch(function(e) {
+        self.log('sqlite/error', e);
+        return {
+            status: 500,
+            body: {
+                type: 'delete_error',
+                title: 'Internal error in Cassandra table storage backend',
+                stack: e.stack,
+                err: e,
+                req: req
+            }
+        };
+    });
+};
+
+RBSQLite.prototype.getTableSchema = function(rb, req) {
+    var self = this;
+    var domain = req.params.domain;
+    return this.store.getTableSchema(domain, req.params.table)
+    .then(function(res) {
+        return {
+            status: 200,
+            headers: {etag: res.tid.toString()},
+            body: res.schema
+        };
+    })
+    .catch(function(e) {
+        self.log('sqlite/error', e);
+        return {
+            status: 500,
+            body: {
+                type: 'schema_query_error',
+                title: 'Internal error querying table schema in Cassandra storage backend',
+                stack: e.stack,
+                err: e,
+                req: req
+            }
+        };
+    });
+};
+
+/*
+ * Setup / startup
+ *
+ * @return {Promise<registry>}
+ */
+RBSQLite.prototype.setup = function setup() {
+    var self = this;
+    // Set up storage backend
+    var DB = require('./lib/db');
+    return P.resolve(new DB(self.options))
+    .then(function(store) {
+        self.store = store;
+        return self.handler;
+    });
+};
+
+
+/**
+ * Factory
+ * @param options
+ * @return {Promise<registration>} with registration being the registration
+ * object
+ */
+function makeRBSQLite(options) {
+    var rb = new RBSQLite(options);
+    return rb.setup();
+}
+
+module.exports = makeRBSQLite;
+

--- a/lib/SchemaMigrator.js
+++ b/lib/SchemaMigrator.js
@@ -1,0 +1,185 @@
+"use strict";
+
+var dbu = require('./dbutils');
+var P = require('bluebird');
+var util = require('util');
+
+
+/**
+ * Base migration handler for unsupported schema
+ */
+function Unsupported(attr, current, proposed) {
+    this.attr = attr;
+    this.current = current;
+    this.proposed = proposed;
+}
+
+Unsupported.prototype.validate = function() {
+    if (this.current.hash !== this.proposed.hash) {
+        throw new Error(this.attr + ' attribute migrations are unsupported');
+    }
+};
+
+Unsupported.prototype.migrate = function() {
+    return P.resolve();
+};
+
+/**
+ * Table name handler
+ */
+function Table(parentMigrator, current, proposed) {
+    Unsupported.call(this, 'table', current, proposed);
+}
+
+util.inherits(Table, Unsupported);
+
+/**
+ * attributes object migration handler
+ */
+function Attributes(parentMigrator, current, proposed, newSchema) {
+    this.client = parentMigrator.db.client;
+    this.log = parentMigrator.db.log;
+    this.conf = parentMigrator.db.conf;
+
+    this.table = parentMigrator.table;
+    this.consistency = parentMigrator.req.consistency;
+    this.current = current;
+    this.proposed = proposed;
+    this.newSchema = newSchema;
+
+    var currSet = new Set(Object.keys(this.current));
+    var propSet = new Set(Object.keys(this.proposed));
+
+    this.addColumns = Array.from(propSet).filter(function(x) { return !currSet.has(x); });
+    // TODO: null-out deleted columns
+    // We can't delete the column in SQLite, but we would remove it from * projection
+    this.delColumns = Array.from(currSet).filter(function(x) { return !propSet.has(x); });
+}
+
+Attributes.prototype.validate = function() {
+    return;
+};
+
+Attributes.prototype._alterTable = function() {
+    return 'ALTER TABLE '+ this.table;
+};
+
+Attributes.prototype._colType = function(col) {
+    return this.newSchema.converters[this.newSchema.attributes[col]].type;
+};
+
+Attributes.prototype._alterTableAdd = function(col) {
+    return this._alterTable()+' ADD COLUMN '+ dbu.fieldName(col) + ' ' + this._colType(col);
+};
+
+Attributes.prototype.migrate = function() {
+    var self = this;
+    return P.each(self.addColumns, function(col) {
+        self.log('warn/schemaMigration/attributes', {
+            message: 'adding column' + col,
+            column: col
+        });
+        var sql = self._alterTableAdd(col);
+        return self.client.run([
+            {sql: sql}
+        ])
+        .catch(function(e) {
+            if (!new RegExp('Invalid column name ' + col
+                + ' because it conflicts with an existing column').test(e.message)) {
+                throw(e);
+            }
+            // Else: Ignore the error if the column already exists.
+        });
+
+    });
+};
+
+/**
+ * Index definition migrations
+ */
+function Index(parentMigrator, current, proposed) {
+    Unsupported.call(this, 'index', current, proposed);
+}
+
+util.inherits(Index, Unsupported);
+
+
+/**
+ * Version handling
+ */
+function Version(parentMigrator, current, proposed) {
+    this.db = parentMigrator.db;
+    this.current = current;
+    this.proposed = proposed;
+}
+
+// versions must be monotonically increasing.
+Version.prototype.validate = function() {
+    if (this.current >= this.proposed) {
+        throw new Error('new version must be higher than previous');
+    }
+};
+
+Version.prototype.migrate = function() {
+    this.db.log('warn/schemaMigration/version', {
+        current: this.current,
+        proposed: this.proposed,
+    });
+    return P.resolve();
+};
+
+var migrationHandlers = {
+    table: Table,
+    attributes: Attributes,
+    index: Index,
+    version: Version
+};
+
+/**
+ * Schema migration.
+ *
+ * Accepts arguments for the current, and proposed schema as schema-info
+ * objects (hint: the output of dbu#makeSchemaInfo).  Validation of the
+ * proposed migration is performed, and an exception raised if necessary.
+ * Note: The schemas themselves are not validated, only the migration; schema
+ * input should be validated ahead of time using
+ * dbu#validateAndNormalizeSchema).
+ *
+ * @param  {object] client; an instance of DB
+ * @param  {object} schemaFrom; current schema info object.
+ * @param  {object} schemaTo; proposed schema info object.
+ * @throws  {Error} if the proposed migration fails to validate
+ */
+function SchemaMigrator(db, req, table, current, proposed) {
+    this.db = db;
+    this.req = req;
+    this.table = table + '_data';
+    this.current = current;
+    this.proposed = proposed;
+
+    var self = this;
+    this.migrators = Object.keys(migrationHandlers).map(function(key) {
+        return new migrationHandlers[key](self, current[key], proposed[key], proposed);
+    });
+
+    this._validate();
+}
+
+SchemaMigrator.prototype._validate = function() {
+    this.migrators.forEach(function(migrator) {
+        migrator.validate();
+    });
+};
+
+/**
+ * Perform any required migration tasks.
+ *
+ * @return a promise that resolves when the migration tasks are complete
+ */
+SchemaMigrator.prototype.migrate = function() {
+    return P.each(this.migrators, function(migrator) {
+        return migrator.migrate();
+    });
+};
+
+module.exports = SchemaMigrator;

--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -1,0 +1,136 @@
+"use strict";
+
+var P = require('bluebird');
+var sqlite3 = require('sqlite3').verbose();
+var poolModule = require('generic-pool');
+
+P.promisifyAll(sqlite3, {suffix: '_p'});
+
+function Wrapper(options) {
+    var delay = options.conf.retry_delay || 100;
+
+    this.conf = options.conf;
+    this.log = options.log;
+    this.retryLimit = options.conf.retry_limit || 5;
+    this.randomDelay = function() {
+        return Math.ceil(Math.random() * delay);
+    };
+
+    this.connectionPool = poolModule.Pool({
+        name: 'sqlite',
+        create: function(callback) {
+            var client = new sqlite3.Database(options.conf.dbname || 'restbase');
+            callback(null, client);
+        },
+        destroy: function(client) {
+            client.close();
+        },
+        max: 1,
+        idleTimeoutMillis: options.pool_idle_timeout || 10000,
+        log: options.log
+    });
+    P.promisifyAll(this.connectionPool, {suffix: '_p'});
+    this.readerConnection = new sqlite3.Database(options.conf.dbname || 'restbase');
+}
+
+/**
+ * Run a set of queries within a transaction.
+ *
+ * @param queries an array of query objects, containing sql field with SQL
+ *        and params array with query parameters.
+ * @returns {*} operation promise
+ */
+Wrapper.prototype.run = function(queries) {
+    var self = this;
+    var retryCount = 0;
+
+    var beginTransaction = function(client) {
+        if (self.conf.show_sql) {
+            self.log('begin immediate', retryCount);
+        }
+
+        return client.run_p('begin immediate')
+        .then(function() {
+            return client;
+        })
+        .catch(function(err) {
+            if (err && err.cause
+                    && err.cause.code === 'SQLITE_BUSY'
+                    && retryCount++ < self.retryLimit) {
+                return P.delay(self.randomDelay())
+                .then(function() {
+                    return beginTransaction(client);
+                });
+            } else {
+                self.connectionPool.release(client);
+                throw err;
+            }
+        });
+    };
+
+    return self.connectionPool.acquire_p()
+    .then(beginTransaction)
+    .then(function(client) {
+        queries = queries.filter(function(query) {
+            return query && query.sql;
+        });
+        return P.each(queries, function(query) {
+            if (self.conf.show_sql) {
+                self.log(query.sql);
+            }
+            return client.run_p(query.sql, query.params);
+        })
+        .then(function() {
+            return client;
+        })
+        .catch(function(err) {
+            if (self.conf.show_sql) {
+                self.log('rollback');
+            }
+            return client.run_p('rollback')
+            .finally(function() {
+                self.connectionPool.release(client);
+                throw err;
+            });
+        });
+    })
+    .then(function(client) {
+        self.log('commit');
+        return client.run_p('commit')
+        .finally(function() {
+            self.connectionPool.release(client);
+        });
+    });
+};
+
+/**
+ * Run read query and return a result promise
+ *
+ * @param query SQL query to execute
+ * @param params query parameters
+ * @returns {*} query result promise
+ */
+Wrapper.prototype.all = function(query, params) {
+    var self = this;
+    var retryCount = 0;
+    var operation;
+    if (self.conf.show_sql) {
+        self.log(query);
+    }
+    operation = self.readerConnection.all_p(query, params)
+    .catch(function(err) {
+        if (err && err.cause
+                && err.cause.code === 'SQLITE_BUSY'
+                && retryCount++ < self.retryLimit) {
+            return P.delay(self.randomDelay())
+            .then(function() {
+                return operation;
+            });
+        } else {
+            throw err;
+        }
+    });
+    return operation;
+};
+
+module.exports = Wrapper;

--- a/lib/db.js
+++ b/lib/db.js
@@ -3,7 +3,7 @@
 var dbu = require('./dbutils');
 var P = require('bluebird');
 var TimeUuid = require("cassandra-uuid").TimeUuid;
-var SchemaMigrator = require('./schemaMigrator');
+var SchemaMigrator = require('./SchemaMigrator');
 var Wrapper = require('./clientWrapper');
 
 function DB(options) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,320 @@
+"use strict";
+
+var dbu = require('./dbutils');
+var P = require('bluebird');
+var TimeUuid = require("cassandra-uuid").TimeUuid;
+var SchemaMigrator = require('./schemaMigrator');
+var Wrapper = require('./clientWrapper');
+
+function DB(options) {
+    this.conf = options.conf;
+    this.log = options.log;
+    // SQLite client
+    this.client = new Wrapper(options);
+    this.schemaCache = {};
+}
+
+// Info table schema
+DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
+    table: 'meta',
+    attributes: {
+        key: 'string',
+        value: 'json',
+        tid: 'timeuuid'
+    },
+    index: [
+        {attribute: 'key', type: 'hash'},
+        {attribute: 'tid', type: 'range', order: 'desc'}
+    ]
+});
+
+DB.prototype.infoSchemaInfo = dbu.makeSchemaInfo(DB.prototype.infoSchema, true);
+
+DB.prototype.getTableSchema = function(domain, table) {
+    var keyspace = dbu.keyspaceName(domain, table);
+    return this._get(keyspace, {}, 'meta', this.infoSchemaInfo)
+    .then(function(res) {
+        if (res && res.items.length) {
+            return {
+                status: 200,
+                tid: res.items[0].tid,
+                schema: JSON.parse(res.items[0].value)
+            };
+        } else {
+            throw new dbu.HTTPError({
+                status: 404,
+                body: {
+                    type: 'notfound',
+                    title: 'the requested table schema was not found'
+                }
+            });
+        }
+    });
+};
+
+DB.prototype._getSchema = function(keyspace) {
+    return this._get(keyspace, {}, 'meta', this.infoSchemaInfo)
+    .then(function(res) {
+        if (res && res.items.length) {
+            var schema = JSON.parse(res.items[0].value);
+            return dbu.makeSchemaInfo(schema);
+        } else {
+            return null;
+        }
+    });
+};
+
+DB.prototype.createTable = function(domain, req) {
+    var self = this;
+    if (!req.table) {
+        throw new Error('Table name required.');
+    }
+
+    var keyspace = dbu.keyspaceName(domain, req.table);
+
+    return this._getSchema(keyspace)
+    .then(function(currentSchema) {
+        // Validate and normalize the schema
+        var schema = dbu.validateAndNormalizeSchema(req);
+        var schemaInfo = dbu.makeSchemaInfo(schema);
+        var createOperation;
+        if (currentSchema) {
+            if (currentSchema.hash !== schemaInfo.hash) {
+                var migrator;
+                try {
+                    migrator = new SchemaMigrator(self, req, keyspace, currentSchema, schemaInfo);
+                }
+                catch (error) {
+                    throw new dbu.HTTPError({
+                        status: 400,
+                        body: {
+                            type: 'bad_request',
+                            title: 'The table already exists, and its schema cannot be upgraded to the requested schema (' + error + ').',
+                            keyspace: keyspace,
+                            schema: schemaInfo
+                        }
+                    });
+                }
+                createOperation = migrator.migrate()
+                .catch(function(error) {
+                    self.log('error/cassandra/table_update', error);
+                    throw error;
+                });
+            } else {
+                return {status: 201};
+            }
+        } else {
+            createOperation = self._createTable(keyspace, schemaInfo);
+        }
+        return createOperation.then(function() {
+            self.schemaCache[keyspace] = schemaInfo;
+            return self._put(keyspace, {
+                attributes: {
+                    key: 'schema',
+                    value: JSON.stringify(schema)
+                }
+            }, 'meta');
+        });
+    });
+};
+
+DB.prototype._createTable = function(keyspace, schema) {
+    var self = this;
+
+    if (!schema.attributes) {
+        throw new Error('No attribute definitions for table ' + keyspace);
+    }
+
+    return self.client.run([
+        {sql: dbu.buildTableSql(schema, keyspace, 'data')},
+        {sql: dbu.buildTableSql(self.infoSchemaInfo, keyspace, 'meta')},
+        {sql: dbu.buildStaticsTableSql(schema, keyspace)},
+        {sql: dbu.buildIndexViewSql(schema, keyspace)}
+    ]);
+};
+
+DB.prototype.dropTable = function(domain, table) {
+    var self = this;
+    var keyspace = dbu.keyspaceName(domain, table);
+    var deleteRequest = function(schema) {
+        var queries = [
+            {sql: 'drop view ' + keyspace + '_indexView'},
+            {sql: 'drop table ' + keyspace + '_meta'},
+            {sql: 'drop table ' + keyspace + '_data'}
+        ];
+        if (dbu.staticTableExist(schema)) {
+            queries.push({sql: 'drop table ' + keyspace + '_static'});
+        }
+        return self.client.run(queries);
+    };
+
+    if (!self.schemaCache[keyspace]) {
+        return this._getSchema(keyspace)
+        .then(function(schema) {
+            return deleteRequest(schema);
+        });
+    } else {
+        var schema = self.schemaCache[keyspace];
+        delete self.schemaCache[keyspace];
+        return deleteRequest(schema);
+    }
+};
+
+DB.prototype.get = function(domain, req) {
+    var self = this;
+
+    var keyspace = dbu.keyspaceName(domain, req.table);
+
+    if (!self.schemaCache[keyspace]) {
+        return this._getSchema(keyspace)
+        .then(function(schema) {
+            self.schemaCache[keyspace] = schema;
+            return self._get(keyspace, req, 'data', schema);
+        });
+    } else {
+        return self._get(keyspace, req, 'data', self.schemaCache[keyspace]);
+    }
+};
+
+DB.prototype._get = function(keyspace, req, table, schema, includePreparedForDelete) {
+    var self = this;
+    if (!table) {
+        table = 'data';
+    }
+
+    if (!schema) {
+        throw new Error('restbase-sqlite3: No schema for ' + keyspace + '_' + table);
+    }
+    var buildResult = dbu.buildGetQuery(keyspace, req, table, schema, includePreparedForDelete);
+    return self.client.all(buildResult.sql, buildResult.params)
+    .then(function(result) {
+        if (!result) {
+            return {
+                count: 0,
+                items: []
+            };
+        }
+        var rows = [];
+        var convertRow = function(row) {
+            delete row._exist_until;
+            Object.keys(row).forEach(function(key) {
+                row[key] = schema.converters[schema.attributes[key]].read(row[key]);
+            });
+            return row;
+        };
+        if (result instanceof Array) {
+            rows = result.map(convertRow) || [];
+        } else {
+            rows.push(convertRow(result));
+        }
+        result = {
+            count: rows.length,
+            items: rows
+        };
+        if (req.next || req.limit) {
+            result.next = (req.next || 0) + rows.length;
+        }
+        return result;
+    })
+    .catch(function(err) {
+        if (err instanceof Object && err.cause && err.cause.code === 'SQLITE_ERROR') {
+            return {
+                count: 0,
+                items: []
+            };
+        } else {
+            throw err;
+        }
+    });
+};
+
+DB.prototype.put = function(domain, req) {
+    var self = this;
+    var keyspace = dbu.keyspaceName(domain, req.table);
+    if (!self.schemaCache[keyspace]) {
+        return self._getSchema(keyspace)
+        .then(function(schema) {
+            self.schemaCache[keyspace] = schema;
+            return self._put(keyspace, req);
+        });
+    } else {
+        return self._put(keyspace, req);
+    }
+};
+
+DB.prototype._put = function(keyspace, req, table) {
+    var self = this;
+    if (!table) {
+        table = 'data';
+    }
+
+    var schema;
+    if (table === 'meta') {
+        schema = this.infoSchemaInfo;
+    } else if (table === "data") {
+        schema = this.schemaCache[keyspace];
+    }
+
+    if (!schema) {
+        throw new Error('Table not found!');
+    }
+
+    if (!req.attributes[schema.tid]) {
+        req.attributes[schema.tid] = TimeUuid.now().toString();
+    }
+
+    req.timestamp = TimeUuid.fromString(req.attributes[schema.tid].toString()).getDate();
+    var query = dbu.buildPutQuery(req, keyspace, table, schema);
+    var queries = [ query.data ];
+    if (query.static) {
+        queries.push(query.static);
+    }
+    return self.client.run(queries)
+    .then(function() {
+        if (table === 'data') {
+            self._revisionPolicyUpdate(keyspace, req, schema);
+        }
+    })
+    .then(function() {
+        return {status: 201};
+    });
+};
+
+DB.prototype._revisionPolicyUpdate = function(keyspace, query, schema) {
+    var self = this;
+    // Step 1: set _exists_until for required rows
+    if (schema.revisionRetentionPolicy.type === 'latest') {
+        var dataQuery = {
+            table: query.table,
+            attributes: {}
+        };
+        var expireTime = new Date().getTime() + schema.revisionRetentionPolicy.grace_ttl * 1000;
+        schema.iKeys.forEach(function(att) {
+            if (att !== schema.tid) {
+                dataQuery.attributes[att] = query.attributes[att];
+            }
+        });
+        dataQuery.order = {};
+        dataQuery.order[schema.tid] = 'asc';
+        return self._get(keyspace, dataQuery, 'data', schema, false)
+        .then(function(result) {
+            if (result.count > schema.revisionRetentionPolicy.count) {
+                var extraItems = result.items.slice(0, result.count - schema.revisionRetentionPolicy.count);
+                return P.all(extraItems.map(function(item) {
+                    var updateQuery = {
+                        table: query.table,
+                        attributes: item
+                    };
+                    updateQuery.attributes._exist_until = expireTime;
+                    return dbu.buildPutQuery(updateQuery, keyspace, 'data', schema).data;
+                }))
+                .then(function(queries) {
+                    queries.push(dbu.buildDeleteExpiredQuery(schema, keyspace));
+                    return self.client.run(queries);
+                });
+            }
+        });
+    }
+};
+
+module.exports = DB;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -1,0 +1,832 @@
+"use strict";
+
+var extend = require('extend');
+var crypto = require('crypto');
+var stringify = require('json-stable-stringify');
+var TimeUuid = require('cassandra-uuid').TimeUuid;
+
+var dbu = {};
+
+dbu.conversions = {
+    json: {
+        write: JSON.stringify,
+        read: JSON.parse,
+        type: 'blob'
+    },
+    blob: {
+        write: function(blob) {
+            if (!blob) {
+                return null;
+            }
+            if (blob instanceof Buffer) {
+                return blob;
+            } else {
+                return new Buffer(blob);
+            }
+        },
+        read: function(val) {
+            if (!val) {
+                return null;
+            }
+            if (val instanceof Buffer) {
+                return val;
+            } else {
+                return new Buffer(val);
+            }
+        },
+        type: 'blob'
+    },
+    boolean: {
+        read: function(value) {
+            return value !== 0;
+        },
+        write: function(value) {
+            return value ? 1 : 0;
+        },
+        type: 'integer'
+    },
+    decimal: {
+        read: toString(),
+        type: 'integer'
+    },
+    timeuuid: {
+        // On write we shuffle uuid bits so that the timestamp bits end up
+        // first in correct order. This allows to compare time uuid as string
+        read: function(value) {
+            if (value) {
+                value = value.substr(7, 8) + '-'
+                + value.substr(3, 4) + '-1'
+                + value.substr(0, 3) + '-'
+                + value.substr(15);
+            }
+            return value;
+        },
+        write: function(value) {
+            if (value) {
+                if (!TimeUuid.test(value)) {
+                    throw new Error('Illegal uuid value ' + value);
+                }
+                value = value.substr(15, 3)
+                + value.substr(9, 4)
+                + value.substr(0, 8)
+                + value.substr(19);
+            }
+            return value;
+        },
+        type: 'text'
+    },
+    uuid: {
+        read: toString()
+    }
+};
+
+// Conversion factories. We create a function for each type so that it can be
+// compiled monomorphically.
+function toString() {
+    return function(val) {
+        if (val) {
+            return val.toString();
+        }
+        return null;
+    };
+}
+
+function generateSetConverter(convObj) {
+    return {
+        write: function(valArray) {
+            if (!Array.isArray(valArray) || valArray.length === 0) {
+                // Empty set is equivalent to null in Cassandra
+                return null;
+            } else {
+                return JSON.stringify(valArray.map(convObj.write));
+            }
+        },
+        read: function(valJson) {
+            if (!valJson) {
+                return null;
+            }
+            var valArray = JSON.parse(valJson);
+            if (valArray) {
+                valArray = valArray.map(convObj.read);
+                var valSet = new Set(valArray);
+                valArray = [];
+                valSet.forEach(function(val) {
+                    valArray.push(val);
+                });
+                return valArray.sort(function(val1, val2) {
+                    if (typeof val1 === "number"
+                    || (typeof val1 === "object" && val1.constructor === Number)) {
+                        return val1 - val2;
+                    } else {
+                        val1 = JSON.stringify(val1);
+                        val2 = JSON.stringify(val2);
+                        if (val1 === val2) {
+                            return 0;
+                        } else if (val1 < val2) {
+                            return -1;
+                        } else {
+                            return 1;
+                        }
+                    }
+                });
+            }
+            return null;
+        },
+        type: 'blob'
+    };
+}
+
+function generateConverters(schema) {
+    schema.converters = {};
+    Object.keys(schema.attributes).forEach(function(key) {
+        var set_type = /^set<(\w+)>$/.exec(schema.attributes[key]);
+        var obj_type = set_type ? set_type[1] : schema.attributes[key];
+        var obj_converter = dbu.conversions[obj_type] || {};
+        if (!obj_converter.write) {
+            obj_converter.write = function(val) {
+                return val;
+            };
+        }
+        if (!obj_converter.read) {
+            obj_converter.read = function(val) {
+                return val;
+            };
+        }
+        if (!obj_converter.type) {
+            obj_converter.type = obj_type;
+        }
+        if (set_type) {
+            schema.converters[schema.attributes[key]] = generateSetConverter(obj_converter);
+        } else {
+            schema.converters[schema.attributes[key]] = obj_converter;
+        }
+    });
+    return schema;
+}
+
+/*
+ * Error instance wrapping HTTP error responses
+ *
+ * Has the same properties as the original response.
+ */
+function HTTPError(response) {
+    Error.call(this);
+    Error.captureStackTrace(this, HTTPError);
+    this.name = this.constructor.name;
+    this.message = JSON.stringify(response);
+
+    for (var key in response) {
+        this[key] = response[key];
+    }
+}
+
+dbu.HTTPError = HTTPError;
+
+dbu.hashKey = function hashKey(key) {
+    return crypto.Hash('sha1')
+    .update(key)
+    .digest()
+    .toString('base64')
+        // Replace [+/] from base64 with _ (illegal in Cassandra)
+    .replace(/[+\/]/g, '_')
+        // Remove base64 padding, has no entropy
+    .replace(/=+$/, '');
+};
+
+dbu.getValidPrefix = function getValidPrefix(key) {
+    var prefixMatch = /^[a-zA-Z0-9_]+/.exec(key);
+    if (prefixMatch) {
+        return prefixMatch[0];
+    } else {
+        return '';
+    }
+};
+
+dbu.makeValidKey = function makeValidKey(key, length) {
+    var origKey = key;
+    key = key.replace(/_/g, '__')
+    .replace(/\./g, '_');
+    if (!/^[a-zA-Z0-9_]+$/.test(key)) {
+        // Create a new 28 char prefix
+        var validPrefix = dbu.getValidPrefix(key).substr(0, length * 2 / 3);
+        return validPrefix + dbu.hashKey(origKey).substr(0, length - validPrefix.length);
+    } else if (key.length > length) {
+        return key.substr(0, length * 2 / 3) + dbu.hashKey(origKey).substr(0, length / 3);
+    } else {
+        return key;
+    }
+};
+
+dbu.keyspaceName = function(domain, bucket) {
+    var prefix = dbu.makeValidKey(domain, Math.max(26, 48 - bucket.length - 3));
+    return prefix
+        // 6 chars _hash_ to prevent conflicts between domains & table names
+    + '_T_' + dbu.makeValidKey(bucket, 48 - prefix.length - 3);
+};
+
+dbu.fieldName = function(name) {
+    if (/^[a-zA-Z0-9_]+$/.test(name)) {
+        return '"' + name + '"';
+    } else {
+        return '"' + name.replace(/"/g, '""') + '"';
+    }
+};
+
+dbu.makeIndexSchema = function makeIndexSchema(dataSchema, indexName) {
+    var index = dataSchema.secondaryIndexes[indexName];
+    var s = {
+        name: indexName,
+        attributes: {},
+        index: index,
+        iKeys: [],
+        iKeyMap: {}
+    };
+
+    // Build index attributes for the index schema
+    index.forEach(function(elem) {
+        var name = elem.attribute;
+        s.attributes[name] = dataSchema.attributes[name];
+        if (elem.type === 'hash' || elem.type === 'range') {
+            s.iKeys.push(name);
+            s.iKeyMap[name] = elem;
+        }
+    });
+
+    // Make sure the main index keys are included in the new index
+    dataSchema.iKeys.forEach(function(att) {
+        if (!s.attributes[att] && att !== dataSchema.tid) {
+            s.attributes[att] = dataSchema.attributes[att];
+            var indexElem = {type: 'range', order: 'desc'};
+            indexElem.attribute = att;
+            index.push(indexElem);
+            s.iKeys.push(att);
+            s.iKeyMap[att] = indexElem;
+        }
+    });
+
+    // Add the data table's tid as a plain attribute, if not yet included
+    if (!s.attributes[dataSchema.tid]) {
+        var tidKey = dataSchema.tid;
+        s.attributes[tidKey] = dataSchema.attributes[tidKey];
+        s.tid = tidKey;
+    }
+
+    // include the orignal schema's conversion table
+    s.conversions = {};
+    if (dataSchema.conversions) {
+        for (var attr in s.attributes) {
+            if (dataSchema.conversions[attr]) {
+                s.conversions[attr] = dataSchema.conversions[attr];
+            }
+        }
+    }
+    return s;
+};
+
+function findTidElement(schema) {
+    for (var key in schema.index) {
+        if (schema.index.hasOwnProperty(key)) {
+            var element = schema.index[key];
+            if (element.type === 'range'
+                    && element.order === 'desc'
+                    && schema.attributes[element.attribute] === 'timeuuid') {
+                return element.attribute;
+            }
+        }
+    }
+    return null;
+}
+
+dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
+    var psi = extend(true, {}, schema);
+    var tidAttribute = findTidElement(schema);
+
+    if (tidAttribute) {
+        psi.tid = tidAttribute;
+    } else {
+        psi.attributes._tid = 'timeuuid';
+        psi.index.push({attribute: '_tid', type: 'range', order: 'desc'});
+        psi.tid = '_tid';
+    }
+    psi.attributes._exist_until = 'timestamp';
+
+    psi.versioned = false;
+
+    // Create summary data on the primary data index
+    psi.iKeys = dbu.indexKeys(psi.index);
+    psi.iKeyMap = {};
+    psi.index.forEach(function(elem) {
+        psi.iKeyMap[elem.attribute] = elem;
+    });
+
+    // Now create secondary index schemas
+    // Also, create a map from attribute to indexes
+    var attributeIndexes = {};
+    Object.keys(psi.secondaryIndexes).forEach(function(si) {
+        psi.secondaryIndexes[si] = dbu.makeIndexSchema(psi, si);
+        var idx = psi.secondaryIndexes[si];
+        idx.iKeys.forEach(function(att) {
+            if (!attributeIndexes[att]) {
+                attributeIndexes[att] = [si];
+            } else {
+                attributeIndexes[att].push(si);
+            }
+        });
+    });
+    psi.attributeIndexes = attributeIndexes;
+    if (!psi.revisionRetentionPolicy) {
+        psi.revisionRetentionPolicy = {type: 'all'};
+    }
+    psi.proj = Object.keys(psi.attributes);
+    psi.hash = stringify(psi);
+    generateConverters(psi);
+    return psi;
+};
+
+dbu.indexKeys = function indexKeys(index) {
+    var res = [];
+    index.forEach(function(elem) {
+        if (elem.type === 'hash' || elem.type === 'range') {
+            res.push(elem.attribute);
+        }
+    });
+    return res;
+};
+
+dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schema) {
+    // FIXME: define as constants somewhere apropos
+    var minGcGrace = 10;
+    var minKeep = 1;
+    var maxKeep = 1000000000;
+
+    var policy;
+
+    if (schema.revisionRetentionPolicy) {
+        policy = schema.revisionRetentionPolicy;
+        Object.keys(policy).forEach(function(key) {
+            var val = policy[key];
+            switch (key) {
+                case 'type':
+                    if (val !== 'all' && val !== 'latest') {
+                        throw new Error('Invalid revision retention policy type ' + val);
+                    }
+                    break;
+                case 'grace_ttl':
+                    if (typeof(val) !== 'number') {
+                        throw new Error('grace_ttl must be a number');
+                    }
+                    if (val < minGcGrace) {
+                        throw new Error('grace_ttl must be a miniumum of ' + minGcGrace + ' seconds');
+                    }
+                    policy.grace_ttl = val;
+                    break;
+                case 'count':
+                    if (typeof(val) !== 'number') {
+                        throw new Error('count must be a number');
+                    }
+                    if ((val < minKeep) || (val > maxKeep)) {
+                        throw new Error('count must be a value between ' + minKeep + ' and ' + maxKeep);
+                    }
+                    policy.count = val;
+                    break;
+                default:
+                    throw new Error('Unknown revision policy attribute: ' + key);
+            }
+        });
+    }
+
+    return policy;
+};
+
+dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
+    schema.version = schema.version || 1;
+    schema.index = dbu.validateIndexSchema(schema, schema.index);
+    if (!schema.secondaryIndexes) {
+        schema.secondaryIndexes = {};
+    }
+    Object.keys(schema.secondaryIndexes).forEach(function(index) {
+        schema.secondaryIndexes[index] = dbu.validateIndexSchema(schema, schema.secondaryIndexes[index]);
+    });
+    var policy = dbu.validateAndNormalizeRevPolicy(schema);
+    if (policy) {
+        schema.revisionRetentionPolicy = policy;
+    }
+    return schema;
+};
+
+dbu.validateIndexSchema = function validateIndexSchema(schema, index) {
+    if (!Array.isArray(index) || !index.length) {
+        throw new Error("Invalid index " + JSON.stringify(index));
+    }
+    var haveHash = false;
+    index.forEach(function(elem) {
+        if (!schema.attributes[elem.attribute]) {
+            throw new Error('Index element ' + JSON.stringify(elem) + ' is not in attributes!');
+        }
+        switch (elem.type) {
+            case 'hash':
+                haveHash = true;
+                break;
+            case 'range':
+                if (elem.order !== 'asc' && elem.order !== 'desc') {
+                    elem.order = 'desc';
+                }
+                break;
+            case 'static':
+            case 'proj':
+                break;
+            default:
+                throw new Error('Invalid index element encountered! ' + JSON.stringify(elem));
+        }
+    });
+    if (!haveHash) {
+        throw new Error("Indexes without hash are not yet supported!");
+    }
+    return index;
+};
+
+function constructOrder(query, schema) {
+    if (query && query.order) {
+        Object.keys(query.order).forEach(function(key) {
+            var dir = query.order[key];
+            if (dir !== 'asc' && dir !== 'desc') {
+                throw new Error("Invalid sort order " + dir + " on key " + key);
+            }
+            var idxElem = schema.iKeyMap[key];
+            if (!idxElem || idxElem.type !== 'range') {
+                throw new Error("Cannot order on attribute " + key
+                + "; needs to be a range index, but is " + idxElem);
+            }
+        });
+    }
+    var orderTerms = [];
+    Object.keys(schema.iKeyMap).forEach(function(key) {
+        var elem = schema.iKeyMap[key];
+        if (elem.type === 'range') {
+            var dir = query && query.order && query.order[elem.attribute]
+                ? query.order[elem.attribute]
+                : elem.order;
+            orderTerms.push(dbu.fieldName(elem.attribute) + ' ' + dir);
+        }
+    });
+    if (orderTerms.length) {
+        return ' order by ' + orderTerms.join(',') + ' ';
+    } else {
+        return '';
+    }
+}
+
+function constructGroupingByHashKeys(schema) {
+    var groupKeys = [];
+    schema.iKeys.forEach(function(key) {
+        if (schema.iKeyMap[key].type === 'hash') {
+            groupKeys.push(key);
+        }
+    });
+    return ' group by ' + groupKeys.map(dbu.fieldName).join(', ') + ' ';
+}
+
+function constructProj(query, schema) {
+    var projArr = query.proj || schema.proj;
+    var proj;
+    if (Array.isArray(projArr)) {
+        proj = projArr.map(dbu.fieldName).join(',');
+    } else if (projArr.constructor === String) {
+        proj = dbu.fieldName(projArr);
+    } else {
+        throw new Error('Unsupported query proj: ' + projArr + ' of type ' + projArr.constructor);
+    }
+    if (query.distinct) {
+        proj = ' distinct ' + proj + ' ';
+    }
+    return proj;
+}
+
+function isStaticJoinNeeded(query, schema, table) {
+    if (query && query.proj) {
+        if (Array.isArray(query.proj)) {
+            return query.proj.some(function(key) {
+                return schema.iKeyMap[key] && schema.iKeyMap[key].type === 'static';
+            });
+        } else if (query.proj.constructor === String) {
+            return schema.iKeyMap[query.proj] && schema.iKeyMap[query.proj].type === 'static';
+        } else {
+            throw new Error('Unsupported query proj: ' + query.proj + ' of type ' + query.proj.constructor);
+        }
+    } else {
+        return (table === 'data') && Object.keys(schema.iKeyMap).some(function(key) {
+            return schema.iKeyMap[key].type === 'static';
+        });
+    }
+}
+
+dbu.staticTableExist = function(schema) {
+    return isStaticJoinNeeded(null, schema, 'data');
+};
+
+function constructLimit(query) {
+    var sql = '';
+    if (query.limit) {
+        sql += ' limit ' + query.limit;
+    }
+
+    if (query.next) {
+        sql += ' offset ' + query.next;
+    }
+    return sql;
+}
+
+dbu.buildGetQuery = function(keyspace, query, table, schema, includePreparedForDelete) {
+    var proj = constructProj(query, schema);
+    var order = constructOrder(query, schema);
+    var limit = constructLimit(query);
+    var params = [];
+    var condition = '';
+    var sql;
+
+    if (includePreparedForDelete === undefined) {
+        includePreparedForDelete = true;
+    }
+
+    if (query.attributes) {
+        var condResult = buildCondition(query.attributes, schema, includePreparedForDelete);
+        condition = ' where ' + condResult.query + ' ';
+        params = condResult.params;
+    }
+
+    if (query.index) {
+        var indexSchema = schema.secondaryIndexes[query.index];
+        if (!indexSchema) {
+            throw new Error('Index does not exist: ' + query.index);
+        }
+        sql = 'select ' + proj + ' from ' + keyspace + '_indexView' + condition + order + limit;
+    } else {
+        if (isStaticJoinNeeded(query, schema, table)) {
+            sql = 'select ' + proj + ' from ' + keyspace + '_' + table
+            + ' natural left outer join ' + keyspace + '_static';
+        } else {
+            sql = 'select ' + proj + ' from ' + keyspace + '_' + table;
+        }
+        sql += condition + order + limit;
+    }
+    return {sql: sql, params: params};
+};
+
+dbu.buildPutQuery = function(req, keyspace, table, schema) {
+    var dataKVMap = {};
+    var staticKVMap = {};
+    var primaryKeyKVMap = {};
+
+    schema.iKeys.forEach(function(key) {
+        if (req.attributes[key] && (schema.iKeys.indexOf(key) >= 0)) {
+            primaryKeyKVMap[key] = req.attributes[key];
+        }
+    });
+
+    if (!schema) {
+        throw new Error('Table not found!');
+    }
+
+    if (req && req.attributes) {
+        Object.keys(req.attributes).forEach(function(key) {
+            req.attributes[key] = schema.converters[schema.attributes[key]].write(req.attributes[key]);
+        });
+    }
+    schema.iKeys.forEach(function(key) {
+        if (req.attributes[key] === undefined) {
+            throw new Error("Index attribute " + JSON.stringify(key) + " missing in "
+                + JSON.stringify(req) + "; schema: " + JSON.stringify(schema, null, 2));
+        } else {
+            dataKVMap[key] = req.attributes[key];
+            if (schema.iKeyMap[key].type === 'hash') {
+                staticKVMap[key] = req.attributes[key];
+            }
+        }
+    });
+
+    var staticNeeded = false;
+
+    for (var key in req.attributes) {
+        var val = req.attributes[key];
+        if (val !== undefined && schema.attributes[key]) {
+            if (!schema.iKeyMap[key]) {
+                dataKVMap[key] = val;
+            } else if (schema.iKeyMap[key].type === 'static') {
+                staticKVMap[key] = val;
+                staticNeeded = true;
+            }
+        }
+    }
+
+    if (req.if && req.if.constructor === String) {
+        req.if = req.if.trim().split(/\s+/).join(' ').toLowerCase();
+    }
+
+    var staticSql;
+    var sql;
+    var dataParams = [];
+
+    if (req.if instanceof Object) {
+        var condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema);
+        sql = 'update ' + keyspace + '_' + table + ' set ';
+        sql += Object.keys(dataKVMap)
+        .filter(function(column) {
+            return schema.iKeys.indexOf(column) < 0;
+        })
+        .map(function(column) {
+            dataParams.push(dataKVMap[column]);
+            return dbu.fieldName(column) + '= ?';
+        }).join(',');
+        sql += ' where ' + condition.query;
+        dataParams = dataParams.concat(condition.params);
+    } else {
+        var keyList = Object.keys(dataKVMap);
+        var proj = keyList.map(dbu.fieldName).join(',');
+        if (req.if === 'not exists') {
+            sql = 'insert or ignore ';
+        } else {
+            sql = 'insert or replace ';
+        }
+        sql += 'into ' + keyspace + '_' + table + ' (' + proj + ') values (';
+        sql += Array.apply(null, new Array(keyList.length)).map(function() {
+            return '?';
+        }).join(', ') + ')';
+
+        Object.keys(dataKVMap).map(function(key) {
+            dataParams.push(dataKVMap[key]);
+        });
+    }
+
+    if (staticNeeded) {
+        staticSql = 'insert or replace into ' + keyspace + '_static ('
+            + Object.keys(staticKVMap).map(dbu.fieldName).join(', ')
+            + ') values ('
+            + Object.keys(staticKVMap).map(function() {
+                return '?';
+            }).join(', ') + ')';
+    }
+    var result = {
+        data: {
+            sql: sql,
+            params: dataParams
+        }
+    };
+    if (staticNeeded) {
+        result.static = {
+            sql: staticSql,
+            params: Object.keys(staticKVMap).map(function(key) {
+                return staticKVMap[key];
+            })
+        };
+    }
+    return result;
+};
+
+function buildCondition(pred, schema, includePreparedForDelete) {
+    var params = [];
+    var conjunctions = [];
+    Object.keys(pred).forEach(function(predKey) {
+        var predObj = pred[predKey];
+        var sql = dbu.fieldName(predKey);
+        if (predObj === undefined) {
+            throw new Error('Query error: attribute ' + JSON.stringify(predKey) + ' is undefined');
+        } else if (predObj === null || predObj.constructor !== Object) {
+            // Default to equality
+            sql += ' = ?';
+            params.push(schema.converters[schema.attributes[predKey]].write(predObj));
+        } else {
+            var predKeys = Object.keys(predObj);
+            if (predKeys.length === 1) {
+                var predOp = predKeys[0];
+                var predArg = predObj[predOp];
+                switch (predOp.toLowerCase()) {
+                    case 'eq':
+                        sql += ' = ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'lt':
+                        sql += ' < ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'gt':
+                        sql += ' > ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'le':
+                        sql += ' <= ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'ge':
+                        sql += ' >= ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'neq':
+                    case 'ne':
+                        sql += ' != ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'between':
+                        sql += ' >= ?' + ' AND ';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg[0]));
+                        sql += dbu.fieldName(predKey) + ' <= ?';
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg[1]));
+                        break;
+                    default:
+                        throw new Error('Operator ' + predOp + ' not supported!');
+                }
+            } else {
+                throw new Error('Invalid predicate ' + JSON.stringify(pred));
+            }
+        }
+        conjunctions.push(sql);
+    });
+    // Also include check that _exist_until not expired
+    if (includePreparedForDelete) {
+        conjunctions.push('(' + dbu.fieldName('_exist_until') + ' > ? OR '
+            + dbu.fieldName('_exist_until') + ' is null )');
+        params.push(new Date().getTime());
+    } else {
+        conjunctions.push(dbu.fieldName('_exist_until') + ' is null');
+    }
+    return {
+        query: conjunctions.join(' AND '),
+        params: params
+    };
+}
+
+dbu.buildStaticsTableSql = function(schema, keyspace) {
+    var staticFields = [];
+    var hashKeys = [];
+    var hasRangeKey = false;
+    schema.index.forEach(function(index) {
+        if (index.type === 'static') {
+            if (schema.iKeyMap[index.attribute]
+                    && schema.iKeyMap[index.attribute].type === 'hash') {
+                throw new Error('Hash key cannot be a static column');
+            }
+            staticFields.push(index.attribute);
+        } else if (index.type === 'hash') {
+            hashKeys.push(index.attribute);
+        } else if (index.type === 'range') {
+            hasRangeKey = true;
+        }
+    });
+    if (staticFields.length === 0) {
+        return;
+    }
+    if (hashKeys.length === 0) {
+        throw new Error('Trying to create a static column without a hash key');
+    }
+    if (!hasRangeKey) {
+        throw new Error('Cannot create static columns without a range key');
+    }
+    var sql = 'create table if not exists ';
+    sql += keyspace + '_static (';
+    sql += hashKeys.concat(staticFields).map(function(key) {
+        return dbu.fieldName(key) + ' ' + schema.converters[schema.attributes[key]].type;
+    }).join(', ');
+    sql += ', primary key (' + hashKeys.map(dbu.fieldName).join(', ') + '), ';
+    sql += 'foreign key (' + hashKeys.map(dbu.fieldName).join(', ') + ') ';
+    sql += 'references ' + keyspace + '_data )';
+    return sql;
+};
+
+dbu.buildTableSql = function(schema, keyspace, table) {
+    var indexKeys = [];
+    var sql = 'create table if not exists ' + keyspace + '_' + table + ' (';
+    sql += Object.keys(schema.attributes)
+    .filter(function(attr) {
+        return !schema.iKeyMap[attr] || schema.iKeyMap[attr].type !== 'static';
+    })
+    .map(function(attr) {
+        if (schema.iKeyMap[attr]
+        && (schema.iKeyMap[attr].type === 'hash' || schema.iKeyMap[attr].type === 'range')) {
+            indexKeys.push(attr);
+        }
+        return dbu.fieldName(attr) + ' ' + schema.converters[schema.attributes[attr]].type;
+    })
+    .join(', ');
+    sql += ', primary key (' + indexKeys.map(dbu.fieldName).join(', ') + ') )';
+    return sql;
+};
+
+dbu.buildIndexViewSql = function(schema, keyspace) {
+    var grouping = constructGroupingByHashKeys(schema);
+    var order = constructOrder(null, schema);
+    var sql = 'create view if not exists ' + keyspace + '_indexView as ';
+    sql += ' select * from ' + keyspace + '_data';
+    if (isStaticJoinNeeded(null, schema, 'data')) {
+        sql += ' natural left outer join ' + keyspace + '_static ';
+    }
+    sql += grouping + order;
+    return sql;
+};
+
+dbu.buildDeleteExpiredQuery = function(schema, keyspace) {
+    return {
+        sql: 'delete from ' + keyspace + '_data where ' + dbu.fieldName('_exist_until') + ' < ?',
+        params: [new Date().getTime()]
+    };
+};
+
+module.exports = dbu;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "restbase-mod-table-sqlite",
+  "description": "RESTBase table storage using sqlite for testing purposes",
+  "version": "0.0.1",
+  "dependencies": {
+    "bluebird": "~2.3.10",
+    "extend": "~2.0.0",
+    "js-yaml": "^3.2.5",
+  	"sqlite3": "*",
+    "cassandra-uuid": "^0.0.2",
+    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
+    "restbase-mod-table-spec": "git+https://github.com/wikimedia/restbase-mod-table-spec#master",
+    "generic-pool": "2.2.0"
+  },
+  "devDependencies": {
+    "coveralls": "2.11.2",
+    "istanbul": "0.3.5",
+    "mocha-lcov-reporter": "0.0.1",
+    "mocha": "x.x.x",
+    "mocha-jshint": "0.0.9"
+  },
+  "scripts": {
+    "test": "rm test_db; mocha",
+    "coverage": "istanbul cover _mocha -- -R spec"
+  }
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,21 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, context, before, beforeEach, after, afterEach */
+
+var yaml = require('js-yaml');
+var fs = require("fs");
+
+describe('Functional', function() {
+    var conf = yaml.safeLoad(fs.readFileSync(__dirname + '/test_client.conf.yaml'));
+    var dbConstructor = require('../index.js');
+    require('restbase-mod-table-spec').test(function() {
+        return dbConstructor({
+            conf: conf,
+            log: function() {}
+        });
+    });
+});
+
+// Run jshint as part of normal testing
+require('mocha-jshint')();

--- a/test/test_client.conf.yaml
+++ b/test/test_client.conf.yaml
@@ -1,0 +1,5 @@
+type: restbase-cassandra
+dbname: test_db
+show_sql: true
+pool_idle_timeout: 10000
+retry_delay: 100


### PR DESCRIPTION
Added SQLite backend. All functional backed tests pass.
2 sqlite connections are managed: one for reads and one for writes.
The write connection is wrapped into a single-element resource pool
to manage job queueing, because concurrent transactions are not supported.

Possible optimisations not yet included:
- Investigate with WAL mode
- Create separate tables for secondary indices
- Write table metadata into a single table
- Create a native SQLite index over all `hash` portions of a primary key

Bug: https://phabricator.wikimedia.org/T88191
