### PR TITLE
Added separate secondary index tables for faster lookup

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -134,16 +134,18 @@ DB.prototype.createTable = function(domain, req) {
 
 DB.prototype._createTable = function(tableName, schema) {
     var self = this;
+    var queries = [];
 
     if (!schema.attributes) {
         throw new Error('No attribute definitions for table ' + tableName);
     }
 
-    return self.client.run([
-        {sql: dbu.buildTableSql(schema, tableName)},
-        {sql: dbu.buildStaticsTableSql(schema, tableName)},
-        {sql: dbu.buildIndexViewSql(schema, tableName)}
-    ]);
+    queries.push({sql: dbu.buildTableSql(schema, tableName)});
+    queries.push({sql: dbu.buildStaticsTableSql(schema, tableName)});
+    dbu.buildSecondaryIndexTableSql(schema, tableName).forEach(function(sql) {
+        queries = queries.concat({sql: sql});
+    });
+    return self.client.run(queries);
 };
 
 DB.prototype.dropTable = function(domain, bucket) {
@@ -151,10 +153,13 @@ DB.prototype.dropTable = function(domain, bucket) {
     var tableName = domain + '_' + bucket;
     var deleteRequest = function(schema) {
         var queries = [
-            {sql: 'drop view [' + tableName + '_indexView]'},
             {sql: 'drop table [' + tableName + '_data]'},
             dbu.buildDeleteQuery(self.schemaTableName, {'table' : tableName})
         ];
+        Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
+            queries.push({sql: 'drop index [' + tableName + '_' + indexName + '_index]'});
+            queries.push({sql: 'drop table [' + tableName + '_' + indexName + ']'});
+        });
         if (dbu.staticTableExist(schema)) {
             queries.push({sql: 'drop table [' + tableName + '_static]'});
         }
@@ -269,6 +274,9 @@ DB.prototype._put = function(tableName, req) {
     if (query.static) {
         queries.push(query.static);
     }
+    dbu.buildSecondaryIndexUpdateQuery(req, tableName, schema).forEach(function(query) {
+        queries.push(query);
+    });
     return self.client.run(queries)
     .then(function() {
         self._revisionPolicyUpdate(tableName, req, schema);

--- a/lib/db.js
+++ b/lib/db.js
@@ -156,10 +156,13 @@ DB.prototype.dropTable = function(domain, bucket) {
             {sql: 'drop table [' + tableName + '_data]'},
             dbu.buildDeleteQuery(self.schemaTableName, {'table' : tableName})
         ];
-        Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
-            queries.push({sql: 'drop index [' + tableName + '_' + indexName + '_index]'});
-            queries.push({sql: 'drop table [' + tableName + '_' + indexName + ']'});
-        });
+        var secondaryIndexNames = Object.keys(schema.secondaryIndexes);
+        if (secondaryIndexNames.length > 0) {
+            secondaryIndexNames.forEach(function(indexName) {
+                queries.push({sql: 'drop index [' + tableName + '_index_' + indexName + ']'});
+            });
+            queries.push({sql: 'drop table [' + tableName + '_secondaryIndex]'});
+        }
         if (dbu.staticTableExist(schema)) {
             queries.push({sql: 'drop table [' + tableName + '_static]'});
         }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -820,7 +820,7 @@ dbu.buildSecondaryIndexTableSql = function(schema, tableName) {
         var indexSchema = schema.secondaryIndexes[indexName];
         var indexSql = 'create index if not exists [' + tableName + '_index_' + indexName + ']';
         indexSql += ' on [' + tableName + '_secondaryIndex] (';
-        indexSql += getAllKeysOfTypes(indexSchema, 'hash', 'range').map(dbu.fieldName).join(', ') + ')';
+        indexSql += getAllKeysOfTypes(indexSchema, ['hash', 'range']).map(dbu.fieldName).join(', ') + ')';
         result.push(indexSql);
     });
     return result;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -810,8 +810,7 @@ dbu.buildSecondaryIndexTableSql = function(schema, tableName) {
         allKeys.forEach(function(attr) {
             tableSql += dbu.fieldName(attr) + ' ' + schema.converters[indexSchema.attributes[attr]].type + ', ';
         });
-        tableSql += 'primary key (' + primaryKeys.map(dbu.fieldName).join(', ') + ')';
-        tableSql += ', unique (' + getAllKeysOfTypes(indexSchema, 'hash').concat(primaryKeys).join(', ') + ') on conflict replace)';
+        tableSql += 'primary key (' + primaryKeys.map(dbu.fieldName).join(', ') + ') )';
         result.push(tableSql);
 
         // Next, create an index over indexed columns for fast lookup

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -182,6 +182,12 @@ function HTTPError(response) {
 
 dbu.HTTPError = HTTPError;
 
+function getAllKeysOfTypes(schema, types) {
+    return Object.keys(schema.iKeyMap).filter(function(key) {
+        return schema.iKeyMap[key] && types.indexOf(schema.iKeyMap[key].type) >= 0;
+    });
+}
+
 dbu.hashKey = function hashKey(key) {
     return crypto.Hash('sha1')
     .update(key)
@@ -233,13 +239,6 @@ dbu.makeIndexSchema = function makeIndexSchema(dataSchema, indexName) {
         }
     });
 
-    // Add the data table's tid as a plain attribute, if not yet included
-    if (!s.attributes[dataSchema.tid]) {
-        var tidKey = dataSchema.tid;
-        s.attributes[tidKey] = dataSchema.attributes[tidKey];
-        s.tid = tidKey;
-    }
-
     // include the orignal schema's conversion table
     s.conversions = {};
     if (dataSchema.conversions) {
@@ -249,6 +248,9 @@ dbu.makeIndexSchema = function makeIndexSchema(dataSchema, indexName) {
             }
         }
     }
+
+    // Construct the default projection
+    s.proj = Object.keys(s.attributes);
     return s;
 };
 
@@ -445,21 +447,16 @@ function constructOrder(query, schema) {
     }
 }
 
-function constructGroupingByHashKeys(schema) {
-    var groupKeys = [];
-    schema.iKeys.forEach(function(key) {
-        if (schema.iKeyMap[key].type === 'hash') {
-            groupKeys.push(key);
-        }
-    });
-    return ' group by ' + groupKeys.map(dbu.fieldName).join(', ') + ' ';
-}
-
 function constructProj(query, schema) {
     var projArr = query.proj || schema.proj;
     var proj;
     if (Array.isArray(projArr)) {
-        proj = projArr.map(dbu.fieldName).join(',');
+        proj = projArr.map(function(attr) {
+            if (!schema.attributes[attr]) {
+                throw new Error('Unknown attribute in projection ' + attr);
+            }
+            return dbu.fieldName(attr);
+        }).join(',');
     } else if (projArr.constructor === String) {
         proj = dbu.fieldName(projArr);
     } else {
@@ -506,8 +503,7 @@ function constructLimit(query) {
 }
 
 dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete) {
-    var proj = constructProj(query, schema);
-    var order = constructOrder(query, schema);
+    var proj;
     var limit = constructLimit(query);
     var params = [];
     var condition = '';
@@ -528,14 +524,16 @@ dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete)
         if (!indexSchema) {
             throw new Error('Index does not exist: ' + query.index);
         }
-        sql = 'select ' + proj + ' from [' + tableName + '_indexView]' + condition + order + limit;
+        proj = constructProj(query, indexSchema);
+        sql = 'select ' + proj + ' from [' + tableName + '_' + indexSchema.name + ']' + condition + constructOrder(query, indexSchema) + limit;
     } else {
+        proj = constructProj(query, schema);
         if (isStaticJoinNeeded(query, schema)) {
             sql = 'select ' + proj + ' from [' + tableName + '_data]' + ' natural left outer join [' + tableName + '_static]';
         } else {
             sql = 'select ' + proj + ' from [' + tableName + '_data]';
         }
-        sql += condition + order + limit;
+        sql += condition + constructOrder(query, schema) + limit;
     }
     return {sql: sql, params: params};
 };
@@ -574,7 +572,7 @@ dbu.buildPutQuery = function(req, tableName, schema) {
 
     var staticNeeded = false;
 
-    for (var key in req.attributes) {
+    Object.keys(req.attributes).forEach(function(key) {
         var val = req.attributes[key];
         if (val !== undefined && schema.attributes[key]) {
             if (!schema.iKeyMap[key]) {
@@ -584,7 +582,7 @@ dbu.buildPutQuery = function(req, tableName, schema) {
                 staticNeeded = true;
             }
         }
-    }
+    });
 
     if (req.if && req.if.constructor === String) {
         req.if = req.if.trim().split(/\s+/).join(' ').toLowerCase();
@@ -647,6 +645,32 @@ dbu.buildPutQuery = function(req, tableName, schema) {
             })
         };
     }
+    return result;
+};
+
+dbu.buildSecondaryIndexUpdateQuery = function(req, tableName, schema) {
+    var result = [];
+    Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
+        var indexSchema = schema.secondaryIndexes[indexName];
+        var dataKVMap = {};
+
+        Object.keys(req.attributes)
+        .filter(function(key) {
+            return Object.keys(indexSchema.attributes).indexOf(key) >= 0
+                        || (schema.iKeyMap[key] && schema.iKeyMap[key].type === 'hash');
+        })
+        .forEach(function(key) {
+            dataKVMap[key] = req.attributes[key];
+        });
+
+        var sql = 'insert or replace into [' + tableName + '_' + indexName + '] (';
+        sql += Object.keys(dataKVMap).map(dbu.fieldName).join(', ') + ') values (';
+        sql += Object.keys(dataKVMap).map(function() { return '?'; }).join(', ') + ')';
+        result.push({
+            sql : sql,
+            params: Object.keys(dataKVMap).map(function(key) { return dataKVMap[key]; })
+        });
+    });
     return result;
 };
 
@@ -760,17 +784,13 @@ dbu.buildStaticsTableSql = function(schema, tableName) {
 };
 
 dbu.buildTableSql = function(schema, tableName) {
-    var indexKeys = [];
+    var indexKeys = getAllKeysOfTypes(schema, ['hash', 'range']);
     var sql = 'create table if not exists ' + '[' + tableName + '_data] (';
     sql += Object.keys(schema.attributes)
     .filter(function(attr) {
         return !schema.iKeyMap[attr] || schema.iKeyMap[attr].type !== 'static';
     })
     .map(function(attr) {
-        if (schema.iKeyMap[attr]
-        && (schema.iKeyMap[attr].type === 'hash' || schema.iKeyMap[attr].type === 'range')) {
-            indexKeys.push(attr);
-        }
         return dbu.fieldName(attr) + ' ' + schema.converters[schema.attributes[attr]].type;
     })
     .join(', ');
@@ -778,16 +798,29 @@ dbu.buildTableSql = function(schema, tableName) {
     return sql;
 };
 
-dbu.buildIndexViewSql = function(schema, tableName) {
-    var grouping = constructGroupingByHashKeys(schema);
-    var order = constructOrder(null, schema);
-    var sql = 'create view if not exists [' + tableName + '_indexView] as ';
-    sql += ' select * from [' + tableName + '_data]';
-    if (isStaticJoinNeeded(null, schema)) {
-        sql += ' natural left outer join [' + tableName + '_static] ';
-    }
-    sql += grouping + order;
-    return sql;
+dbu.buildSecondaryIndexTableSql = function(schema, tableName) {
+    var result = [];
+    Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
+        // First create a table to hold secondary indexes
+        var indexSchema = schema.secondaryIndexes[indexName];
+        var tableSql = 'create table if not exists ' + '[' + tableName + '_' + indexName + '] (';
+        var primaryKeys = getAllKeysOfTypes(schema, ['hash']);
+        var allKeys = new Set(primaryKeys);
+        Object.keys(indexSchema.attributes).forEach(function(key) { allKeys.add(key); });
+        allKeys.forEach(function(attr) {
+            tableSql += dbu.fieldName(attr) + ' ' + schema.converters[indexSchema.attributes[attr]].type + ', ';
+        });
+        tableSql += 'primary key (' + primaryKeys.map(dbu.fieldName).join(', ') + ')';
+        tableSql += ', unique (' + getAllKeysOfTypes(indexSchema, 'hash').concat(primaryKeys).join(', ') + ') on conflict replace)';
+        result.push(tableSql);
+
+        // Next, create an index over indexed columns for fast lookup
+        var indexSql = 'create index if not exists [' + tableName + '_' + indexName + '_index]';
+        indexSql += ' on [' + tableName + '_' + indexName + '] (';
+        indexSql += getAllKeysOfTypes(indexSchema, 'hash').map(dbu.fieldName).join(', ') + ')';
+        result.push(indexSql);
+    });
+    return result;
 };
 
 dbu.buildDeleteExpiredQuery = function(schema, tableName) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -290,25 +290,25 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
         psi.iKeyMap[elem.attribute] = elem;
     });
 
-    // Now create secondary index schemas
-    // Also, create a map from attribute to indexes
-    var attributeIndexes = {};
-    Object.keys(psi.secondaryIndexes).forEach(function(si) {
-        psi.secondaryIndexes[si] = dbu.makeIndexSchema(psi, si);
-        var idx = psi.secondaryIndexes[si];
-        idx.iKeys.forEach(function(att) {
-            if (!attributeIndexes[att]) {
-                attributeIndexes[att] = [si];
-            } else {
-                attributeIndexes[att].push(si);
-            }
-        });
-    });
-    psi.attributeIndexes = attributeIndexes;
     if (!psi.revisionRetentionPolicy) {
         psi.revisionRetentionPolicy = {type: 'all'};
     }
     psi.proj = Object.keys(psi.attributes);
+
+    // Secondary index primary key === main table hash + range keys - tid
+    psi.secondaryIndexPrimaryKeys = getAllKeysOfTypes(psi, ['hash', 'range'])
+    .filter(function(key) {
+        return key !== psi.tid;
+    });
+    // All secondary index keys joined
+    psi.allSecondaryIndexKeys = new Set(psi.secondaryIndexPrimaryKeys);
+    Object.keys(psi.secondaryIndexes).forEach(function(indexName) {
+        psi.secondaryIndexes[indexName] = dbu.makeIndexSchema(psi, indexName);
+        Object.keys(psi.secondaryIndexes[indexName].attributes).forEach(function(key) {
+            psi.allSecondaryIndexKeys.add(key);
+        });
+    });
+
     psi.hash = stringify(psi);
     generateConverters(psi);
     return psi;
@@ -525,7 +525,7 @@ dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete)
             throw new Error('Index does not exist: ' + query.index);
         }
         proj = constructProj(query, indexSchema);
-        sql = 'select ' + proj + ' from [' + tableName + '_' + indexSchema.name + ']' + condition + constructOrder(query, indexSchema) + limit;
+        sql = 'select ' + proj + ' from [' + tableName + '_secondaryIndex]' + condition + constructOrder(query, indexSchema) + limit;
     } else {
         proj = constructProj(query, schema);
         if (isStaticJoinNeeded(query, schema)) {
@@ -650,27 +650,29 @@ dbu.buildPutQuery = function(req, tableName, schema) {
 
 dbu.buildSecondaryIndexUpdateQuery = function(req, tableName, schema) {
     var result = [];
-    Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
-        var indexSchema = schema.secondaryIndexes[indexName];
-        var dataKVMap = {};
+    var secondaryIndexNames = Object.keys(schema.secondaryIndexes);
+    var dataKVMap = {};
+    var sql;
 
-        Object.keys(req.attributes)
-        .filter(function(key) {
-            return Object.keys(indexSchema.attributes).indexOf(key) >= 0
-                        || (schema.iKeyMap[key] && schema.iKeyMap[key].type === 'hash');
-        })
-        .forEach(function(key) {
-            dataKVMap[key] = req.attributes[key];
-        });
+    if (secondaryIndexNames.length === 0) {
+        return result;
+    }
 
-        var sql = 'insert or replace into [' + tableName + '_' + indexName + '] (';
-        sql += Object.keys(dataKVMap).map(dbu.fieldName).join(', ') + ') values (';
-        sql += Object.keys(dataKVMap).map(function() { return '?'; }).join(', ') + ')';
-        result.push({
-            sql : sql,
-            params: Object.keys(dataKVMap).map(function(key) { return dataKVMap[key]; })
-        });
+    sql = 'insert or replace into [' + tableName + '_secondaryIndex] (';
+    Object.keys(req.attributes)
+    .filter(function(key) {
+        return schema.allSecondaryIndexKeys.has(key);
+    })
+    .forEach(function(key) {
+        dataKVMap[key] = req.attributes[key];
     });
+    sql += Object.keys(dataKVMap).map(dbu.fieldName).join(', ') + ') values (';
+    sql += Object.keys(dataKVMap).map(function() { return '?'; }).join(', ') + ')';
+    result.push({
+        sql : sql,
+        params: Object.keys(dataKVMap).map(function(key) { return dataKVMap[key]; })
+    });
+
     return result;
 };
 
@@ -800,23 +802,25 @@ dbu.buildTableSql = function(schema, tableName) {
 
 dbu.buildSecondaryIndexTableSql = function(schema, tableName) {
     var result = [];
-    Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
-        // First create a table to hold secondary indexes
-        var indexSchema = schema.secondaryIndexes[indexName];
-        var tableSql = 'create table if not exists ' + '[' + tableName + '_' + indexName + '] (';
-        var primaryKeys = getAllKeysOfTypes(schema, ['hash']);
-        var allKeys = new Set(primaryKeys);
-        Object.keys(indexSchema.attributes).forEach(function(key) { allKeys.add(key); });
-        allKeys.forEach(function(attr) {
-            tableSql += dbu.fieldName(attr) + ' ' + schema.converters[indexSchema.attributes[attr]].type + ', ';
-        });
-        tableSql += 'primary key (' + primaryKeys.map(dbu.fieldName).join(', ') + ') )';
-        result.push(tableSql);
+    var secondaryIndexNames = Object.keys(schema.secondaryIndexes);
+    var tableSql;
+    if (secondaryIndexNames.length === 0) {
+        return result;
+    }
 
-        // Next, create an index over indexed columns for fast lookup
-        var indexSql = 'create index if not exists [' + tableName + '_' + indexName + '_index]';
-        indexSql += ' on [' + tableName + '_' + indexName + '] (';
-        indexSql += getAllKeysOfTypes(indexSchema, 'hash').map(dbu.fieldName).join(', ') + ')';
+    tableSql = 'create table if not exists ' + '[' + tableName + '_secondaryIndex] (';
+    schema.allSecondaryIndexKeys.forEach(function(attr) {
+        tableSql += dbu.fieldName(attr) + ' ' + schema.converters[schema.attributes[attr]].type + ', ';
+    });
+    tableSql += 'primary key (' + schema.secondaryIndexPrimaryKeys.map(dbu.fieldName).join(', ') + ') )';
+    result.push(tableSql);
+
+    // Next, create SQLite indexes over secondary index key columns for faster lookup
+    Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
+        var indexSchema = schema.secondaryIndexes[indexName];
+        var indexSql = 'create index if not exists [' + tableName + '_index_' + indexName + ']';
+        indexSql += ' on [' + tableName + '_secondaryIndex] (';
+        indexSql += getAllKeysOfTypes(indexSchema, 'hash', 'range').map(dbu.fieldName).join(', ') + ')';
         result.push(indexSql);
     });
     return result;


### PR DESCRIPTION
After discussion with @gwicke is was decided that it's better to have separate secondary indexes tables in sqlite the same way as in cassandra. The reason is that in sqlite we have to construct complex nested queries to mimic cassandra secondary indexes behaviour, which is extremelly inefficient. As read/write ratio is really huge, read performance is way more important that write performance, and as private wikis generally don't contain lot's of data, some data duplication is ok. 

This PR provides a solution for that. The secondary index table is constructed to hold a conjunction of all projections of all secondary indexes, with primary key = main table hash + range keys - tid. This allows to mimic cassandra behaviour with single 'insert or replace' query.

For lookup speed we also create an native SQLite index over `index_key_attrs` for every index.

On revision policy updates we don't need to handle secondary indexes, because if the row is obsolete and needed to be removed, we anyway have already overwritten the secondary index tables for that row (as it's not the last by range keys).

Another idea was to store only data required for lookup in the secondary index table, and make a join on select. This is implemented here: https://github.com/Pchelolo/restbase-mod-table-sqlite/tree/secondary_indexes_join It's not clear which is faster, naive benchmark of restbase using both implementation as a backend shows that current version is slightly faster (15.033s/10000 requests vs 15.2516s/10000 requests). It's also simpler and less error-prone, but a bit more storage-size consuming. Not sure which one to use. 

PS: fun fact, naive RB benchmarks on my laptop shows that for small installations SQLite backend is ~30% faster than cassandra backend.
