### PR TITLE
Added string value converter to avoid automatic conversion to number

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -13,6 +13,21 @@ dbu.conversions = {
         read: JSON.parse,
         type: 'blob'
     },
+    string: {
+        write: function(value) {
+            if (value) {
+                return value.toString();
+            }
+            return value;
+        },
+        read: function(value) {
+            if (value && typeof value !== 'string') {
+                return value.toString();
+            }
+            return value;
+        },
+        type: 'text'
+    },
     blob: {
         write: function(blob) {
             if (!blob) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -14,14 +14,10 @@ dbu.conversions = {
         type: 'blob'
     },
     string: {
-        write: function(value) {
-            if (value) {
-                return value.toString();
-            }
-            return value;
-        },
         read: function(value) {
-            if (value && typeof value !== 'string') {
+            if (value !== null
+                    && value !== undefined
+                    && typeof value !== 'string') {
                 return value.toString();
             }
             return value;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dependencies": {
     "bluebird": "~2.3.10",
     "extend": "~2.0.0",


### PR DESCRIPTION
SQLite automatically converts strings than contain numeric values to numbers, which causes problems in restbase. The test is added in spec project
