### PR TITLE
Cache prepared statements for get requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 
 // global includes
 var spec = require('restbase-mod-table-spec').spec;
-var P    = require('bluebird');
 
 function RBSQLite(options) {
     this.options = options;
@@ -182,8 +181,8 @@ RBSQLite.prototype.getTableSchema = function(rb, req) {
 RBSQLite.prototype.setup = function setup() {
     var self = this;
     // Set up storage backend
-    var DB = require('./lib/db');
-    return P.resolve(new DB(self.options))
+    var createDB = require('./lib/db');
+    return createDB(self.options)
     .then(function(store) {
         self.store = store;
         return self.handler;

--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -114,11 +114,11 @@ Wrapper.prototype.all = function(query, params) {
     var self = this;
     var retryCount = 0;
     if (self.conf.show_sql) {
-        self.log(query.sql);
+        self.log(query.sql, params);
     }
 
     function operation() {
-        return query.all_p(query, params)
+        return query.all_p(params)
         .catch(function(err) {
             if (err && err.cause
             && err.cause.code === 'SQLITE_BUSY'

--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -114,11 +114,11 @@ Wrapper.prototype.all = function(query, params) {
     var self = this;
     var retryCount = 0;
     if (self.conf.show_sql) {
-        self.log(query);
+        self.log(query.sql);
     }
-    
+
     function operation() {
-        return self.readerConnection.all_p(query, params)
+        return query.all_p(query, params)
         .catch(function(err) {
             if (err && err.cause
             && err.cause.code === 'SQLITE_BUSY'
@@ -132,6 +132,10 @@ Wrapper.prototype.all = function(query, params) {
     }
 
     return operation();
+};
+
+Wrapper.prototype.prepare = function(query) {
+    return P.promisifyAll(this.readerConnection.prepare(query), {suffix: '_p'});
 };
 
 module.exports = Wrapper;

--- a/lib/db.js
+++ b/lib/db.js
@@ -192,11 +192,11 @@ DB.prototype.get = function(domain, req) {
         return this._getSchema(tableName)
         .then(function(schema) {
             self.schemaCache[tableName] = schema;
-            return self._get(tableName, req, schema);
+            return self._get(tableName, req, schema, true);
         });
     } else {
         return P.try(function() {
-            return self._get(tableName, req, self.schemaCache[tableName]);
+            return self._get(tableName, req, self.schemaCache[tableName], true);
         });
     }
 };
@@ -204,7 +204,7 @@ DB.prototype.get = function(domain, req) {
 DB.prototype._createGetQuery = function(tableName, req, schema, includePreparedForDelete) {
     var extracted = dbu.extractGetParams(tableName, req, schema, includePreparedForDelete);
     var key = JSON.stringify(req);
-    var query = this.queryCache.get(key );
+    var query = this.queryCache.get(key);
     var getQuery;
     if (query) {
         getQuery = {

--- a/lib/db.js
+++ b/lib/db.js
@@ -15,11 +15,12 @@ function DB(options) {
     this.client = new Wrapper(options);
     this.schemaCache = {};
     this.schemaCache[this.schemaTableName] = this.infoSchemaInfo;
-    this.queryCache = new LRU(100);
-    // Create a table to store schemas
-    this.client.run([
-        {sql: dbu.buildTableSql(this.infoSchemaInfo, this.schemaTableName)}
-    ]);
+    this.queryCache = new LRU({
+        max: 500,
+        dispose: function (key, statement) {
+            statement.finalize();
+        }
+    });
 }
 
 // Info table schema
@@ -66,11 +67,14 @@ DB.prototype.getTableSchema = function(domain, bucket) {
 };
 
 DB.prototype._getSchema = function(tableName) {
-    return this._get(this.schemaTableName, {
-        attributes: {
-            table: tableName
-        }
-    }, this.infoSchemaInfo)
+    var self = this;
+    return P.try(function() {
+        return self._get(self.schemaTableName, {
+            attributes: {
+                table: tableName
+            }
+        }, self.infoSchemaInfo);
+    })
     .then(function(res) {
         if (res && res.items.length) {
             var schema = JSON.parse(res.items[0].value);
@@ -197,27 +201,31 @@ DB.prototype.get = function(domain, req) {
     }
 };
 
+DB.prototype._createGetQuery = function(tableName, req, schema, includePreparedForDelete) {
+    var extracted = dbu.extractGetParams(tableName, req, schema, includePreparedForDelete);
+    var key = JSON.stringify(req);
+    var query = this.queryCache.get(key );
+    var getQuery;
+    if (query) {
+        getQuery = {
+            sql: query,
+            params: extracted
+        };
+    } else {
+        var newQuery = dbu.buildGetQuery(tableName, req, schema, includePreparedForDelete);
+        getQuery = {
+            sql: this.client.prepare(newQuery),
+            params: extracted
+        };
+        this.queryCache.set(key, getQuery.sql);
+    }
+    return getQuery;
+};
+
 DB.prototype._get = function(tableName, req, schema, includePreparedForDelete) {
     var self = this;
-    var buildResult;
-
     validator.validateGetRequest(req, schema);
-
-    var extracted = dbu.extractGetParams(tableName, req, schema, includePreparedForDelete);
-    var query = self.queryCache.get(JSON.stringify(extracted.newReq));
-    if (query) {
-        buildResult = {
-            sql: query,
-            params: extracted.params
-        }
-    } else {
-        buildResult = {
-            sql: dbu.buildGetQuery(tableName, req, schema, includePreparedForDelete),
-            params: extracted.params
-        };
-        self.queryCache.set(JSON.stringify(req), buildResult.sql);
-    }
-
+    var buildResult = self._createGetQuery(tableName, req, schema, includePreparedForDelete);
     return self.client.all(buildResult.sql, buildResult.params)
     .then(function(result) {
         if (!result) {
@@ -320,8 +328,25 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
             };
         }
         dataQuery.order = {};
-        dataQuery.order[schema.tid] = 'desc';
-        return dataQuery;
+        dataQuery.order[schema.tid] = 'asc';
+        return self._get(tableName, dataQuery, schema, false)
+        .then(function(result) {
+            if (result.count > schema.revisionRetentionPolicy.count) {
+                var extraItems = result.items.slice(0, result.count - schema.revisionRetentionPolicy.count);
+                return P.all(extraItems.map(function(item) {
+                    var updateQuery = {
+                        table: query.table,
+                        attributes: item
+                    };
+                    updateQuery.attributes._exist_until = expireTime;
+                    return dbu.buildPutQuery(updateQuery, tableName, schema).data;
+                }))
+                .then(function(queries) {
+                    queries.push(dbu.buildDeleteExpiredQuery(schema, tableName));
+                    return self.client.run(queries);
+                });
+            }
+        });
     }
 
     function setTTLs(result) {
@@ -357,5 +382,13 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
     }
 };
 
-module.exports = DB;
-
+module.exports = function(options) {
+    var db = new DB(options);
+    // Create a table to store schemas
+    return db.client.run([
+        {sql: dbu.buildTableSql(db.infoSchemaInfo, db.schemaTableName)}
+    ])
+    .then(function() {
+        return db;
+    });
+};

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,6 +5,7 @@ var P = require('bluebird');
 var TimeUuid = require("cassandra-uuid").TimeUuid;
 var SchemaMigrator = require('./SchemaMigrator');
 var Wrapper = require('./clientWrapper');
+var LRU = require('lru-cache');
 var validator = require('restbase-mod-table-spec').validator;
 
 function DB(options) {
@@ -14,6 +15,7 @@ function DB(options) {
     this.client = new Wrapper(options);
     this.schemaCache = {};
     this.schemaCache[this.schemaTableName] = this.infoSchemaInfo;
+    this.queryCache = new LRU(100);
     // Create a table to store schemas
     this.client.run([
         {sql: dbu.buildTableSql(this.infoSchemaInfo, this.schemaTableName)}
@@ -201,7 +203,21 @@ DB.prototype._get = function(tableName, req, schema, includePreparedForDelete) {
 
     validator.validateGetRequest(req, schema);
 
-    buildResult = dbu.buildGetQuery(tableName, req, schema, includePreparedForDelete);
+    var extracted = dbu.extractGetParams(tableName, req, schema, includePreparedForDelete);
+    var query = self.queryCache.get(JSON.stringify(extracted.newReq));
+    if (query) {
+        buildResult = {
+            sql: query,
+            params: extracted.params
+        }
+    } else {
+        buildResult = {
+            sql: dbu.buildGetQuery(tableName, req, schema, includePreparedForDelete),
+            params: extracted.params
+        };
+        self.queryCache.set(JSON.stringify(req), buildResult.sql);
+    }
+
     return self.client.all(buildResult.sql, buildResult.params)
     .then(function(result) {
         if (!result) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -203,7 +203,7 @@ DB.prototype.get = function(domain, req) {
 };
 
 DB.prototype._createGetQuery = function(tableName, req, schema, includePreparedForDelete) {
-    var extracted = dbu.extractGetParams(tableName, req, schema, includePreparedForDelete);
+    var extracted = dbu.extractGetParams(req, schema, includePreparedForDelete);
     var key = stringify(req);
     var query = this.queryCache.get(key);
     var getQuery;
@@ -313,6 +313,10 @@ DB.prototype._put = function(tableName, req) {
 DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
     var self = this;
 
+    if (!schema.revisionRetentionPolicy || schema.revisionRetentionPolicy.type === 'all') {
+        return P.resolve();
+    }
+
     function createDataQuery(limitTime) {
         var dataQuery = {
             table: query.table,
@@ -329,25 +333,8 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
             };
         }
         dataQuery.order = {};
-        dataQuery.order[schema.tid] = 'asc';
-        return self._get(tableName, dataQuery, schema, false)
-        .then(function(result) {
-            if (result.count > schema.revisionRetentionPolicy.count) {
-                var extraItems = result.items.slice(0, result.count - schema.revisionRetentionPolicy.count);
-                return P.all(extraItems.map(function(item) {
-                    var updateQuery = {
-                        table: query.table,
-                        attributes: item
-                    };
-                    updateQuery.attributes._exist_until = expireTime;
-                    return dbu.buildPutQuery(updateQuery, tableName, schema).data;
-                }))
-                .then(function(queries) {
-                    queries.push(dbu.buildDeleteExpiredQuery(schema, tableName));
-                    return self.client.run(queries);
-                });
-            }
-        });
+        dataQuery.order[schema.tid] = 'desc';
+        return dataQuery;
     }
 
     function setTTLs(result) {
@@ -369,18 +356,21 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
         }
     }
 
+    var dataQuery;
     // Step 1: set _exists_until for required rows
     if (schema.revisionRetentionPolicy.type === 'latest') {
-        return self._get(tableName, createDataQuery(), schema, false)
-        .then(setTTLs);
+        dataQuery = createDataQuery();
     } else if (schema.revisionRetentionPolicy.type === 'interval') {
         // 1. Need to check if there are enough renders more than 'interval' time ago
         var interval = schema.revisionRetentionPolicy.interval * 1000;
         var tidTime = query.timestamp.getTime();
         var intervalLimitTime = tidTime - tidTime % interval;
-        return self._get(tableName, createDataQuery(intervalLimitTime), schema, false)
-        .then(setTTLs);
+        dataQuery = createDataQuery(intervalLimitTime);
     }
+    return P.try(function() {
+        return self._get(tableName, dataQuery, schema, false);
+    })
+    .then(setTTLs);
 };
 
 module.exports = function(options) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -7,6 +7,7 @@ var SchemaMigrator = require('./SchemaMigrator');
 var Wrapper = require('./clientWrapper');
 var LRU = require('lru-cache');
 var validator = require('restbase-mod-table-spec').validator;
+var stringify = require('json-stable-stringify');
 
 function DB(options) {
     this.conf = options.conf;
@@ -203,7 +204,7 @@ DB.prototype.get = function(domain, req) {
 
 DB.prototype._createGetQuery = function(tableName, req, schema, includePreparedForDelete) {
     var extracted = dbu.extractGetParams(tableName, req, schema, includePreparedForDelete);
-    var key = JSON.stringify(req);
+    var key = stringify(req);
     var query = this.queryCache.get(key);
     var getQuery;
     if (query) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -433,7 +433,7 @@ function extractConditionParams(query, schema) {
     var pred = query.attributes;
     Object.keys(pred).forEach(function(predKey) {
         var predObj = pred[predKey];
-        if (predObj === null || predObj.constructor !== Object) {
+        if (!predObj || predObj.constructor !== Object) {
             params.push(schema.converters[schema.attributes[predKey]].write(predObj));
             pred[predKey] = null;
         } else {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -407,13 +407,9 @@ dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete)
     var condition = '';
     var sql;
 
-    if (includePreparedForDelete === undefined) {
-        includePreparedForDelete = true;
-    }
-
     if (query.attributes) {
-        var condResult = buildCondition(query.attributes, schema, includePreparedForDelete);
-        condition = ' where ' + condResult + ' ';
+        var condResult = buildCondition(query.attributes, schema, includePreparedForDelete, false);
+        condition = ' where ' + condResult.query + ' ';
     }
 
     if (query.index) {
@@ -429,7 +425,7 @@ dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete)
         }
         sql += condition + constructOrder(query, schema) + limit;
     }
-    return sql
+    return sql;
 };
 
 function extractConditionParams(query, schema) {
@@ -459,10 +455,9 @@ function extractConditionParams(query, schema) {
 }
 
 dbu.extractGetParams = function(tableName, query, schema, includePreparedForDelete) {
-    var newQuery = JSON.parse(JSON.stringify(query));
     var params;
     if (query.attributes) {
-        params = extractConditionParams(newQuery, schema);
+        params = extractConditionParams(query, schema);
     } else {
         params = [];
     }
@@ -471,49 +466,10 @@ dbu.extractGetParams = function(tableName, query, schema, includePreparedForDele
     if (includePreparedForDelete) {
         params.push(new Date().getTime());
     } else {
-        query.includePreparedForDelete = false;
+        query.includePreparedForDelete = 'no';
     }
-    return {
-        newReq: newQuery,
-        params: params
-    };
+    return params;
 };
-
-/*dbu.extractPutParams = function(tableName, query, schema) {
-    var dataKVMap = {};
-    var staticKVMap = {};
-    var primaryKeyKVMap = {};
-    var dataParams = {};
-
-    schema.iKeys.forEach(function(key) {
-        if (query.attributes[key] && (schema.iKeys.indexOf(key) >= 0)) {
-            primaryKeyKVMap[key] = query.attributes[key];
-        }
-    });
-
-    if (query && query.attributes) {
-        Object.keys(query.attributes).forEach(function(key) {
-            query.attributes[key] = schema.converters[schema.attributes[key]].write(query.attributes[key]);
-        });
-    }
-    schema.iKeys.forEach(function(key) {
-        if (query.attributes[key] === undefined) {
-            throw new Error("Index attribute " + JSON.stringify(key) + " missing in "
-                + JSON.stringify(query) + "; schema: " + JSON.stringify(schema, null, 2));
-        } else {
-            dataKVMap[key] = query.attributes[key];
-            if (schema.iKeyMap[key].type === 'hash') {
-                staticKVMap[key] = query.attributes[key];
-            }
-        }
-    });
-
-    if (query.if instanceof Object) {
-
-    } else {
-
-    }
-};*/
 
 dbu.buildPutQuery = function(req, tableName, schema) {
     var dataKVMap = {};
@@ -561,7 +517,7 @@ dbu.buildPutQuery = function(req, tableName, schema) {
     var dataParams = [];
 
     if (req.if instanceof Object) {
-        var condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema);
+        var condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema, false, true);
         sql = 'update [' + tableName + '_data] set ';
         sql += Object.keys(dataKVMap)
         .filter(function(column) {
@@ -571,7 +527,8 @@ dbu.buildPutQuery = function(req, tableName, schema) {
             dataParams.push(dataKVMap[column]);
             return dbu.fieldName(column) + '= ?';
         }).join(',');
-        sql += ' where ' + condition;
+        sql += ' where ' + condition.query;
+        dataParams = dataParams.concat(condition.params);
     } else {
         var keyList = Object.keys(dataKVMap);
         var proj = keyList.map(dbu.fieldName).join(',');
@@ -643,7 +600,8 @@ dbu.buildSecondaryIndexUpdateQuery = function(req, tableName, schema) {
     return result;
 };
 
-function buildCondition(pred, schema, includePreparedForDelete) {
+function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
+    var params = [];
     var conjunctions = [];
     Object.keys(pred).forEach(function(predKey) {
         var predObj = pred[predKey];
@@ -651,12 +609,25 @@ function buildCondition(pred, schema, includePreparedForDelete) {
         if (predObj === null || predObj.constructor !== Object) {
             // Default to equality
             sql += ' = ?';
+            if (extractParams) {
+                params.push(schema.converters[schema.attributes[predKey]].write(predObj));
+            }
         } else {
             var predKeys = Object.keys(predObj);
             if (predKeys.length === 1) {
-                var predOp = predKeys[0];
+                var predOp = predKeys[0].toLowerCase();
                 var predArg = predObj[predOp];
-                switch (predOp.toLowerCase()) {
+
+                if (extractParams) {
+                    if (predOp === 'between') {
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg[0]));
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg[1]));
+                    } else {
+                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                    }
+                }
+
+                switch (predOp) {
                     case 'eq':
                         sql += ' = ?';
                         break;
@@ -691,12 +662,17 @@ function buildCondition(pred, schema, includePreparedForDelete) {
     if (includePreparedForDelete) {
         conjunctions.push('(' + dbu.fieldName('_exist_until') + ' > ? OR '
         + dbu.fieldName('_exist_until') + ' is null )');
+        if (extractParams) {
+            params.push(new Date().getTime());
+        }
     } else {
         conjunctions.push(dbu.fieldName('_exist_until') + ' is null');
     }
-    return conjunctions.join(' AND ');
+    return {
+        query: conjunctions.join(' AND '),
+        params: params
+    };
 }
-
 dbu.buildStaticsTableSql = function(schema, tableName) {
     var staticFields = [];
     var hashKeys = [];

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -548,7 +548,7 @@ dbu.buildPutQuery = function(req, tableName, schema) {
     }
 
     if (staticNeeded) {
-        staticSql = 'insert or replace into [' + tableName + '_static] (' 
+        staticSql = 'insert or replace into [' + tableName + '_static] ('
             + Object.keys(staticKVMap).map(dbu.fieldName).join(', ')
             + ') values ('
             + Object.keys(staticKVMap).map(function() {
@@ -605,18 +605,16 @@ function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
     var conjunctions = [];
     Object.keys(pred).forEach(function(predKey) {
         var predObj = pred[predKey];
-        var sql = dbu.fieldName(predKey);
         if (predObj === null || predObj.constructor !== Object) {
             // Default to equality
-            sql += ' = ?';
+            conjunctions.push(dbu.fieldName(predKey) + ' = ?');
             if (extractParams) {
                 params.push(schema.converters[schema.attributes[predKey]].write(predObj));
             }
         } else {
-            var predKeys = Object.keys(predObj);
-            if (predKeys.length === 1) {
-                var predOp = predKeys[0].toLowerCase();
+            Object.keys(predObj).forEach(function(predOp) {
                 var predArg = predObj[predOp];
+                var sql = dbu.fieldName(predKey);
 
                 if (extractParams) {
                     if (predOp === 'between') {
@@ -627,7 +625,7 @@ function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
                     }
                 }
 
-                switch (predOp) {
+                switch (predOp.toLowerCase()) {
                     case 'eq':
                         sql += ' = ?';
                         break;
@@ -643,25 +641,20 @@ function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
                     case 'ge':
                         sql += ' >= ?';
                         break;
-                    case 'neq':
-                    case 'ne':
-                        sql += ' != ?';
-                        break;
                     case 'between':
                         sql += ' >= ?' + ' AND ';
                         sql += dbu.fieldName(predKey) + ' <= ?';
                         break;
-                    default:
-                        throw new Error('Operator ' + predOp + ' not supported!');
+                    default: throw new Error ('Operator ' + predOp + ' not supported!');
                 }
-            }
+                conjunctions.push(sql);
+            });
         }
-        conjunctions.push(sql);
     });
     // Also include check that _exist_until not expired
     if (includePreparedForDelete) {
         conjunctions.push('(' + dbu.fieldName('_exist_until') + ' > ? OR '
-        + dbu.fieldName('_exist_until') + ' is null )');
+            + dbu.fieldName('_exist_until') + ' is null )');
         if (extractParams) {
             params.push(new Date().getTime());
         }
@@ -680,10 +673,6 @@ dbu.buildStaticsTableSql = function(schema, tableName) {
     var hasRangeKey = false;
     schema.index.forEach(function(index) {
         if (index.type === 'static') {
-            if (schema.iKeyMap[index.attribute]
-                    && schema.iKeyMap[index.attribute].type === 'hash') {
-                throw new Error('Hash key cannot be a static column');
-            }
             staticFields.push(index.attribute);
         } else if (index.type === 'hash') {
             hashKeys.push(index.attribute);

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -404,7 +404,6 @@ function constructLimit(query) {
 dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete) {
     var proj;
     var limit = constructLimit(query);
-    var params = [];
     var condition = '';
     var sql;
 
@@ -414,8 +413,7 @@ dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete)
 
     if (query.attributes) {
         var condResult = buildCondition(query.attributes, schema, includePreparedForDelete);
-        condition = ' where ' + condResult.query + ' ';
-        params = condResult.params;
+        condition = ' where ' + condResult + ' ';
     }
 
     if (query.index) {
@@ -431,8 +429,91 @@ dbu.buildGetQuery = function(tableName, query, schema, includePreparedForDelete)
         }
         sql += condition + constructOrder(query, schema) + limit;
     }
-    return {sql: sql, params: params};
+    return sql
 };
+
+function extractConditionParams(query, schema) {
+    var params = [];
+    var pred = query.attributes;
+    Object.keys(pred).forEach(function(predKey) {
+        var predObj = pred[predKey];
+        if (predObj === null || predObj.constructor !== Object) {
+            params.push(schema.converters[schema.attributes[predKey]].write(predObj));
+            pred[predKey] = null;
+        } else {
+            var predKeys = Object.keys(predObj);
+            var predOp = predKeys[0];
+            var predArg = predObj[predOp];
+            if (predOp.toLowerCase() === 'between') {
+                params.push(schema.converters[schema.attributes[predKey]].write(predArg[0]));
+                params.push(schema.converters[schema.attributes[predKey]].write(predArg[1]));
+                predArg[0] = null;
+                predArg[1] = null;
+            } else {
+                params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                predObj[predOp] = null;
+            }
+        }
+    });
+    return params;
+}
+
+dbu.extractGetParams = function(tableName, query, schema, includePreparedForDelete) {
+    var newQuery = JSON.parse(JSON.stringify(query));
+    var params;
+    if (query.attributes) {
+        params = extractConditionParams(newQuery, schema);
+    } else {
+        params = [];
+    }
+
+    // Also include check that _exist_until not expired
+    if (includePreparedForDelete) {
+        params.push(new Date().getTime());
+    } else {
+        query.includePreparedForDelete = false;
+    }
+    return {
+        newReq: newQuery,
+        params: params
+    };
+};
+
+/*dbu.extractPutParams = function(tableName, query, schema) {
+    var dataKVMap = {};
+    var staticKVMap = {};
+    var primaryKeyKVMap = {};
+    var dataParams = {};
+
+    schema.iKeys.forEach(function(key) {
+        if (query.attributes[key] && (schema.iKeys.indexOf(key) >= 0)) {
+            primaryKeyKVMap[key] = query.attributes[key];
+        }
+    });
+
+    if (query && query.attributes) {
+        Object.keys(query.attributes).forEach(function(key) {
+            query.attributes[key] = schema.converters[schema.attributes[key]].write(query.attributes[key]);
+        });
+    }
+    schema.iKeys.forEach(function(key) {
+        if (query.attributes[key] === undefined) {
+            throw new Error("Index attribute " + JSON.stringify(key) + " missing in "
+                + JSON.stringify(query) + "; schema: " + JSON.stringify(schema, null, 2));
+        } else {
+            dataKVMap[key] = query.attributes[key];
+            if (schema.iKeyMap[key].type === 'hash') {
+                staticKVMap[key] = query.attributes[key];
+            }
+        }
+    });
+
+    if (query.if instanceof Object) {
+
+    } else {
+
+    }
+};*/
 
 dbu.buildPutQuery = function(req, tableName, schema) {
     var dataKVMap = {};
@@ -490,8 +571,7 @@ dbu.buildPutQuery = function(req, tableName, schema) {
             dataParams.push(dataKVMap[column]);
             return dbu.fieldName(column) + '= ?';
         }).join(',');
-        sql += ' where ' + condition.query;
-        dataParams = dataParams.concat(condition.params);
+        sql += ' where ' + condition;
     } else {
         var keyList = Object.keys(dataKVMap);
         var proj = keyList.map(dbu.fieldName).join(',');
@@ -511,7 +591,7 @@ dbu.buildPutQuery = function(req, tableName, schema) {
     }
 
     if (staticNeeded) {
-        staticSql = 'insert or replace into [' + tableName + '_static] ('
+        staticSql = 'insert or replace into [' + tableName + '_static] (' 
             + Object.keys(staticKVMap).map(dbu.fieldName).join(', ')
             + ') values ('
             + Object.keys(staticKVMap).map(function() {
@@ -564,7 +644,6 @@ dbu.buildSecondaryIndexUpdateQuery = function(req, tableName, schema) {
 };
 
 function buildCondition(pred, schema, includePreparedForDelete) {
-    var params = [];
     var conjunctions = [];
     Object.keys(pred).forEach(function(predKey) {
         var predObj = pred[predKey];
@@ -572,7 +651,6 @@ function buildCondition(pred, schema, includePreparedForDelete) {
         if (predObj === null || predObj.constructor !== Object) {
             // Default to equality
             sql += ' = ?';
-            params.push(schema.converters[schema.attributes[predKey]].write(predObj));
         } else {
             var predKeys = Object.keys(predObj);
             if (predKeys.length === 1) {
@@ -581,29 +659,26 @@ function buildCondition(pred, schema, includePreparedForDelete) {
                 switch (predOp.toLowerCase()) {
                     case 'eq':
                         sql += ' = ?';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
                         break;
                     case 'lt':
                         sql += ' < ?';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
                         break;
                     case 'gt':
                         sql += ' > ?';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
                         break;
                     case 'le':
                         sql += ' <= ?';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
                         break;
                     case 'ge':
                         sql += ' >= ?';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg));
+                        break;
+                    case 'neq':
+                    case 'ne':
+                        sql += ' != ?';
                         break;
                     case 'between':
                         sql += ' >= ?' + ' AND ';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg[0]));
                         sql += dbu.fieldName(predKey) + ' <= ?';
-                        params.push(schema.converters[schema.attributes[predKey]].write(predArg[1]));
                         break;
                     default:
                         throw new Error('Operator ' + predOp + ' not supported!');
@@ -615,15 +690,11 @@ function buildCondition(pred, schema, includePreparedForDelete) {
     // Also include check that _exist_until not expired
     if (includePreparedForDelete) {
         conjunctions.push('(' + dbu.fieldName('_exist_until') + ' > ? OR '
-            + dbu.fieldName('_exist_until') + ' is null )');
-        params.push(new Date().getTime());
+        + dbu.fieldName('_exist_until') + ' is null )');
     } else {
         conjunctions.push(dbu.fieldName('_exist_until') + ' is null');
     }
-    return {
-        query: conjunctions.join(' AND '),
-        params: params
-    };
+    return conjunctions.join(' AND ');
 }
 
 dbu.buildStaticsTableSql = function(schema, tableName) {
@@ -632,6 +703,10 @@ dbu.buildStaticsTableSql = function(schema, tableName) {
     var hasRangeKey = false;
     schema.index.forEach(function(index) {
         if (index.type === 'static') {
+            if (schema.iKeyMap[index.attribute]
+            && schema.iKeyMap[index.attribute].type === 'hash') {
+                throw new Error('Hash key cannot be a static column');
+            }
             staticFields.push(index.attribute);
         } else if (index.type === 'hash') {
             hashKeys.push(index.attribute);
@@ -703,7 +778,7 @@ dbu.buildDeleteExpiredQuery = function(schema, tableName) {
 
 dbu.buildDeleteQuery = function(tableName, keys) {
     var sql = 'delete from [' + tableName + '_data] where ';
-    var params  = [];
+    var params = [];
     sql += Object.keys(keys).map(function(key) {
         params.push(keys[key]);
         return ' ' + dbu.fieldName(key) + ' = ? ';

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -593,7 +593,7 @@ dbu.buildSecondaryIndexUpdateQuery = function(req, tableName, schema) {
     sql += Object.keys(dataKVMap).map(dbu.fieldName).join(', ') + ') values (';
     sql += Object.keys(dataKVMap).map(function() { return '?'; }).join(', ') + ')';
     result.push({
-        sql : sql,
+        sql: sql,
         params: Object.keys(dataKVMap).map(function(key) { return dataKVMap[key]; })
     });
 
@@ -673,6 +673,7 @@ function buildCondition(pred, schema, includePreparedForDelete, extractParams) {
         params: params
     };
 }
+
 dbu.buildStaticsTableSql = function(schema, tableName) {
     var staticFields = [];
     var hashKeys = [];
@@ -680,7 +681,7 @@ dbu.buildStaticsTableSql = function(schema, tableName) {
     schema.index.forEach(function(index) {
         if (index.type === 'static') {
             if (schema.iKeyMap[index.attribute]
-            && schema.iKeyMap[index.attribute].type === 'hash') {
+                    && schema.iKeyMap[index.attribute].type === 'hash') {
                 throw new Error('Hash key cannot be a static column');
             }
             staticFields.push(index.attribute);
@@ -754,7 +755,7 @@ dbu.buildDeleteExpiredQuery = function(schema, tableName) {
 
 dbu.buildDeleteQuery = function(tableName, keys) {
     var sql = 'delete from [' + tableName + '_data] where ';
-    var params = [];
+    var params  = [];
     sql += Object.keys(keys).map(function(key) {
         params.push(keys[key]);
         return ' ' + dbu.fieldName(key) + ' = ? ';

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -454,7 +454,7 @@ function extractConditionParams(query, schema) {
     return params;
 }
 
-dbu.extractGetParams = function(tableName, query, schema, includePreparedForDelete) {
+dbu.extractGetParams = function(query, schema, includePreparedForDelete) {
     var params;
     if (query.attributes) {
         params = extractConditionParams(query, schema);
@@ -466,7 +466,7 @@ dbu.extractGetParams = function(tableName, query, schema, includePreparedForDele
     if (includePreparedForDelete) {
         params.push(new Date().getTime());
     } else {
-        query.includePreparedForDelete = 'no';
+        query.includePreparedForDelete = false;
     }
     return params;
 };

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "restbase-mod-table-spec": "^0.0.3",
     "generic-pool": "^2.2.0",
-    "lru-cache": "^2.6.5",
-    "json-stable-stringify": "^1.0.0"
+    "lru-cache": "^2.6.5"
   },
   "devDependencies": {
     "coveralls": "^2.11.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "restbase-mod-table-spec": "^0.0.3",
     "generic-pool": "^2.2.0",
-    "lru-cache": "^2.6.5"
+    "lru-cache": "^2.6.5",
+    "json-stable-stringify": "^1.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "restbase-mod-table-spec": "^0.0.3",
-    "generic-pool": "^2.2.0"
+    "generic-pool": "^2.2.0",
+    "lru-cache": "^2.6.5"
   },
   "devDependencies": {
     "coveralls": "^2.11.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is an implementation of an idea to cache db prepared statements. This gives ~20% improvement in read speed (from 290s to 240s for 100000 requests to a restbase endpoint). While being great for reads, it's unnecessary for writes, as we don't have that much of them and it's better to keep code cleaner.
