### PR TITLE
Fixed a bug in retries

### DIFF
--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -113,11 +113,11 @@ Wrapper.prototype.run = function(queries) {
 Wrapper.prototype.all = function(query, params) {
     var self = this;
     var retryCount = 0;
-    var operation;
     if (self.conf.show_sql) {
         self.log(query);
     }
-    operation = function() {
+    
+    function operation() {
         return self.readerConnection.all_p(query, params)
         .catch(function(err) {
             if (err && err.cause
@@ -129,7 +129,8 @@ Wrapper.prototype.all = function(query, params) {
                 throw err;
             }
         });
-    };
+    }
+
     return operation();
 };
 

--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -117,20 +117,20 @@ Wrapper.prototype.all = function(query, params) {
     if (self.conf.show_sql) {
         self.log(query);
     }
-    operation = self.readerConnection.all_p(query, params)
-    .catch(function(err) {
-        if (err && err.cause
-                && err.cause.code === 'SQLITE_BUSY'
-                && retryCount++ < self.retryLimit) {
-            return P.delay(self.randomDelay())
-            .then(function() {
-                return operation;
-            });
-        } else {
-            throw err;
-        }
-    });
-    return operation;
+    operation = function() {
+        return self.readerConnection.all_p(query, params)
+        .catch(function(err) {
+            if (err && err.cause
+            && err.cause.code === 'SQLITE_BUSY'
+            && retryCount++ < self.retryLimit) {
+                return P.delay(self.randomDelay())
+                .then(operation);
+            } else {
+                throw err;
+            }
+        });
+    };
+    return operation();
 };
 
 module.exports = Wrapper;


### PR DESCRIPTION
This is a bug I've found while working on tests: retries didn't work in case we get SQLITE_BUSY error. The problem is that in case of a retry we were returning the exact same promise, which was already partially resolved, so nothing happened, the program simply hang. Now we recreate the promise on each retry - heavy testing shows no hang-ups any more
