### PR TITLE
Implemented 'interval' policy support

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -287,36 +287,66 @@ DB.prototype._put = function(tableName, req) {
 
 DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
     var self = this;
-    // Step 1: set _exists_until for required rows
-    if (schema.revisionRetentionPolicy.type === 'latest') {
+    var dataQuery;
+
+    function createDataQuery() {
         var dataQuery = {
             table: query.table,
             attributes: {}
         };
-        var expireTime = new Date().getTime() + schema.revisionRetentionPolicy.grace_ttl * 1000;
         schema.iKeys.forEach(function(att) {
             if (att !== schema.tid) {
                 dataQuery.attributes[att] = query.attributes[att];
             }
         });
         dataQuery.order = {};
-        dataQuery.order[schema.tid] = 'asc';
+        dataQuery.order[schema.tid] = 'desc';
+        return dataQuery;
+    }
+
+    function setTTL(result) {
+        var expireTime = new Date().getTime() + schema.revisionRetentionPolicy.grace_ttl * 1000;
+        if (result.count > schema.revisionRetentionPolicy.count) {
+            var extraItems = result.items.slice(result.count - schema.revisionRetentionPolicy.count);
+            return P.all(extraItems.map(function(item) {
+                var updateQuery = {
+                    table: query.table,
+                    attributes: item
+                };
+                updateQuery.attributes._exist_until = expireTime;
+                return dbu.buildPutQuery(updateQuery, tableName, schema).data;
+            }))
+            .then(function(queries) {
+                queries.push(dbu.buildDeleteExpiredQuery(schema, tableName));
+                return self.client.run(queries);
+            });
+        }
+    }
+
+    // Step 1: set _exists_until for required rows
+    if (schema.revisionRetentionPolicy.type === 'latest') {
+        dataQuery = createDataQuery();
+        return self._get(tableName, dataQuery, schema, false)
+        .then(setTTL);
+    } else if (schema.revisionRetentionPolicy.type === 'interval') {
+        // 1. Need to check if there are enough renders more than 'interval' time ago
+        var interval = schema.revisionRetentionPolicy.interval * 1000;
+        dataQuery = createDataQuery();
+        dataQuery.attributes[schema.tid] = {
+            lt: TimeUuid.fromDate(new Date().setTime(new Date().getTime() - interval))
+        };
+        dataQuery.limit = schema.revisionRetentionPolicy.count;
         return self._get(tableName, dataQuery, schema, false)
         .then(function(result) {
-            if (result.count > schema.revisionRetentionPolicy.count) {
-                var extraItems = result.items.slice(0, result.count - schema.revisionRetentionPolicy.count);
-                return P.all(extraItems.map(function(item) {
-                    var updateQuery = {
-                        table: query.table,
-                        attributes: item
-                    };
-                    updateQuery.attributes._exist_until = expireTime;
-                    return dbu.buildPutQuery(updateQuery, tableName, schema).data;
-                }))
-                .then(function(queries) {
-                    queries.push(dbu.buildDeleteExpiredQuery(schema, tableName));
-                    return self.client.run(queries);
-                });
+            // 2. If no, keep the renders
+            if (result.count !== schema.revisionRetentionPolicy.count) {
+                // 3. If yes, scroll all revisions until 'interval' or first with TTL and set TTL
+                dataQuery = createDataQuery();
+                dataQuery.attributes[schema.tid] = {
+                    ge: TimeUuid.fromDate(new Date().setTime(new Date().getTime() - interval))
+                };
+                return self._get(tableName, dataQuery, schema, false)
+                .then(setTTL);
             }
         });
     }

--- a/lib/db.js
+++ b/lib/db.js
@@ -304,10 +304,10 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
         return dataQuery;
     }
 
-    function setTTL(result) {
+    function setTTLs(result) {
         var expireTime = new Date().getTime() + schema.revisionRetentionPolicy.grace_ttl * 1000;
         if (result.count > schema.revisionRetentionPolicy.count) {
-            var extraItems = result.items.slice(result.count - schema.revisionRetentionPolicy.count);
+            var extraItems = result.items.slice(schema.revisionRetentionPolicy.count);
             return P.all(extraItems.map(function(item) {
                 var updateQuery = {
                     table: query.table,
@@ -325,31 +325,33 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
 
     // Step 1: set _exists_until for required rows
     if (schema.revisionRetentionPolicy.type === 'latest') {
-        dataQuery = createDataQuery();
-        return self._get(tableName, dataQuery, schema, false)
-        .then(setTTL);
+        return self._get(tableName, createDataQuery(), schema, false)
+        .then(setTTLs);
     } else if (schema.revisionRetentionPolicy.type === 'interval') {
         // 1. Need to check if there are enough renders more than 'interval' time ago
         var interval = schema.revisionRetentionPolicy.interval * 1000;
-        dataQuery = createDataQuery();
-        dataQuery.attributes[schema.tid] = {
-            lt: TimeUuid.fromDate(new Date().setTime(new Date().getTime() - interval))
-        };
-        dataQuery.limit = schema.revisionRetentionPolicy.count;
-        return self._get(tableName, dataQuery, schema, false)
+        var tidTime = query.timestamp.getTime();
+        var intervalLimitTime = new Date(tidTime - interval);
+        return self._get(tableName, createDataQuery(), schema, false)
         .then(function(result) {
-            // 2. If no, keep the renders
-            if (result.count !== schema.revisionRetentionPolicy.count) {
-                // 3. If yes, scroll all revisions until 'interval' or first with TTL and set TTL
-                dataQuery = createDataQuery();
-                dataQuery.attributes[schema.tid] = {
-                    ge: TimeUuid.fromDate(new Date().setTime(new Date().getTime() - interval))
-                };
-                return self._get(tableName, dataQuery, schema, false)
-                .then(setTTL);
+            var candidates = [];
+            for (var idx = 0; idx < result.count; idx++) {
+                if (result.items.hasOwnProperty(idx)) {
+                    var item = result.items[idx];
+                    if (TimeUuid.fromString(item[schema.tid]).getDate() > intervalLimitTime
+                            && !item._exist_until) {
+                        candidates.push(item);
+                    } else {
+                        return setTTLs({
+                            count: candidates.length,
+                            items: candidates
+                        });
+                    }
+                }
             }
         });
     }
 };
 
 module.exports = DB;
+

--- a/lib/db.js
+++ b/lib/db.js
@@ -288,7 +288,7 @@ DB.prototype._put = function(tableName, req) {
 DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
     var self = this;
 
-    function createDataQuery() {
+    function createDataQuery(limitTime) {
         var dataQuery = {
             table: query.table,
             attributes: {}
@@ -298,6 +298,11 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
                 dataQuery.attributes[att] = query.attributes[att];
             }
         });
+        if (limitTime) {
+            dataQuery.attributes[schema.tid] = {
+                ge: TimeUuid.fromDate(new Date(limitTime)).toString()
+            };
+        }
         dataQuery.order = {};
         dataQuery.order[schema.tid] = 'desc';
         return dataQuery;
@@ -330,25 +335,9 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
         // 1. Need to check if there are enough renders more than 'interval' time ago
         var interval = schema.revisionRetentionPolicy.interval * 1000;
         var tidTime = query.timestamp.getTime();
-        var intervalLimitTime = new Date(tidTime - interval);
-        return self._get(tableName, createDataQuery(), schema, false)
-        .then(function(result) {
-            var candidates = [];
-            for (var idx = 0; idx < result.count; idx++) {
-                if (result.items.hasOwnProperty(idx)) {
-                    var item = result.items[idx];
-                    if (TimeUuid.fromString(item[schema.tid]).getDate() > intervalLimitTime
-                            && !item._exist_until) {
-                        candidates.push(item);
-                    } else {
-                        return setTTLs({
-                            count: candidates.length,
-                            items: candidates
-                        });
-                    }
-                }
-            }
-        });
+        var intervalLimitTime = tidTime - tidTime % interval;
+        return self._get(tableName, createDataQuery(intervalLimitTime), schema, false)
+        .then(setTTLs);
     }
 };
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -287,7 +287,6 @@ DB.prototype._put = function(tableName, req) {
 
 DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
     var self = this;
-    var dataQuery;
 
     function createDataQuery() {
         var dataQuery = {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sqlite3": "3.x.x",
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.0.2",
+    "restbase-mod-table-spec": "/Users/pchelko/sandbox/wiki/restbase-mod-table-spec/restbase-mod-table-spec",
     "generic-pool": "^2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "sqlite3": "3.x.x",
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "/Users/pchelko/sandbox/wiki/restbase-mod-table-spec/restbase-mod-table-spec",
+    "restbase-mod-table-spec": "^0.0.3",
     "generic-pool": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The PR implements an `interval` option for revision retention policy for SQLite backend using and algorithm, described in a ticket.

Note: this PR depends on spec one: https://github.com/wikimedia/restbase-mod-table-spec/pull/12

Bug: https://phabricator.wikimedia.org/T94524
