### PR TITLE
Added support for static columns addition

### DIFF
--- a/lib/SchemaMigrator.js
+++ b/lib/SchemaMigrator.js
@@ -36,7 +36,7 @@ util.inherits(Table, Unsupported);
 /**
  * attributes object migration handler
  */
-function Attributes(parentMigrator, current, proposed, newSchema) {
+function Attributes(parentMigrator, current, proposed) {
     this.client = parentMigrator.db.client;
     this.log = parentMigrator.db.log;
     this.conf = parentMigrator.db.conf;
@@ -45,7 +45,8 @@ function Attributes(parentMigrator, current, proposed, newSchema) {
     this.consistency = parentMigrator.req.consistency;
     this.current = current;
     this.proposed = proposed;
-    this.newSchema = newSchema;
+    this.newSchema = parentMigrator.proposed;
+    this.oldSchema = parentMigrator.current;
 
     var currSet = new Set(Object.keys(this.current));
     var propSet = new Set(Object.keys(this.proposed));
@@ -60,8 +61,8 @@ Attributes.prototype.validate = function() {
     return;
 };
 
-Attributes.prototype._alterTable = function() {
-    return 'ALTER TABLE ['+ this.table + ']';
+Attributes.prototype._alterTable = function(fullTableName) {
+    return 'ALTER TABLE ['+ fullTableName + ']';
 };
 
 Attributes.prototype._colType = function(col) {
@@ -69,7 +70,17 @@ Attributes.prototype._colType = function(col) {
 };
 
 Attributes.prototype._alterTableAdd = function(col) {
-    return this._alterTable()+' ADD COLUMN '+ dbu.fieldName(col) + ' ' + this._colType(col);
+    var colIndex = this.newSchema.index
+       && this.newSchema.index.find(function(index) { return index.attribute === col; });
+    if (colIndex && colIndex.type === 'static') {
+        if (!dbu.staticTableExist(this.oldSchema)) {
+            return dbu.buildStaticsTableSql(this.newSchema, this.table);
+        } else {
+            return this._alterTable(this.table + '_static') + ' ADD COLUMN '+ dbu.fieldName(col) + ' ' + this._colType(col);
+        }
+    } else {
+        return this._alterTable(this.table + '_data') + ' ADD COLUMN '+ dbu.fieldName(col) + ' ' + this._colType(col);
+    }
 };
 
 Attributes.prototype.migrate = function() {
@@ -80,17 +91,15 @@ Attributes.prototype.migrate = function() {
             column: col
         });
         var sql = self._alterTableAdd(col);
-        return self.client.run([
-            {sql: sql}
-        ])
+        return self.client.run([{sql: sql}])
         .catch(function(e) {
             if (!new RegExp('Invalid column name ' + col
-                + ' because it conflicts with an existing column').test(e.message)) {
+                    + ' because it conflicts with an existing column').test(e.message)
+                    && !/duplicate column name/.test(e.message)) {
+                // Ignore the error if the column already exists.
                 throw(e);
             }
-            // Else: Ignore the error if the column already exists.
         });
-
     });
 };
 
@@ -98,10 +107,55 @@ Attributes.prototype.migrate = function() {
  * Index definition migrations
  */
 function Index(parentMigrator, current, proposed) {
-    Unsupported.call(this, 'index', current, proposed);
+    var self = this;
+    self.current = current;
+    self.proposed = proposed;
+    self.currentSchema = parentMigrator.current;
+    self.proposedSchema = parentMigrator.proposed;
+
+    self.addIndex = proposed.filter(function(x) { return !self._hasSameIndex(self.current, x); });
+    self.delIndex = current.filter(function(x) { return !self._hasSameIndex(self.proposed, x); });
+
+    self.alteredColumns = [];
+
+    // If index added and the column existed previously, need to remove it and add back to change index.
+    // Not supported.
+    self.addIndex.forEach(function(index) {
+        if (self.currentSchema.attributes[index.attribute]) {
+            self.alteredColumns.push(index.attribute);
+        }
+    });
+
+    // If index deleted the column is not deleted, need to remove it and add back to change index.
+    // Not supported.
+    self.delIndex.forEach(function(index) {
+        if (self.proposedSchema.attributes[index.attribute]) {
+            self.alteredColumns.push(index.attribute);
+        }
+    });
 }
 
-util.inherits(Index, Unsupported);
+Index.prototype.validate = function() {
+    var self = this;
+    if (self.addIndex.some(function(index) { return index.type !== 'static'; })
+    || self.delIndex.some(function(index) { return index.type !== 'static'; })) {
+        throw new Error('Only static index additions and removals supported');
+    }
+    if (self.alteredColumns.length > 0) {
+        throw new Error('Changing index on existing column not supported');
+    }
+};
+
+Index.prototype._hasSameIndex = function(indexes, proposedIndex) {
+    return indexes.some(function(idx) {
+        return idx.attribute === proposedIndex.attribute
+        && idx.type === proposedIndex.type
+        && idx.order === proposedIndex.order;
+    });
+};
+
+Index.prototype.migrate = function() {
+};
 
 
 /**
@@ -123,7 +177,7 @@ Version.prototype.validate = function() {
 Version.prototype.migrate = function() {
     this.db.log('warn/schemaMigration/version', {
         current: this.current,
-        proposed: this.proposed,
+        proposed: this.proposed
     });
     return P.resolve();
 };
@@ -152,13 +206,13 @@ var migrationHandlers = {
 function SchemaMigrator(db, req, table, current, proposed) {
     this.db = db;
     this.req = req;
-    this.table = table + '_data';
+    this.table = table;
     this.current = current;
     this.proposed = proposed;
 
     var self = this;
     this.migrators = Object.keys(migrationHandlers).map(function(key) {
-        return new migrationHandlers[key](self, current[key], proposed[key], proposed);
+        return new migrationHandlers[key](self, current[key], proposed[key]);
     });
 
     this._validate();

--- a/lib/db.js
+++ b/lib/db.js
@@ -118,6 +118,14 @@ DB.prototype.createTable = function(domain, req) {
                     });
                 }
                 createOperation = migrator.migrate()
+                .then(function() {
+                    self.queryCache.keys().filter(function(key) {
+                        return key.indexOf(tableName) === 0;
+                    })
+                    .forEach(function(key) {
+                        self.queryCache.del(key);
+                    });
+                })
                 .catch(function(error) {
                     self.log('error/sqlite/table_update', error);
                     throw error;
@@ -239,7 +247,9 @@ DB.prototype._get = function(tableName, req, schema, includePreparedForDelete) {
         var convertRow = function(row) {
             delete row._exist_until;
             Object.keys(row).forEach(function(key) {
-                row[key] = schema.converters[schema.attributes[key]].read(row[key]);
+                if (schema.attributes[key]) {
+                    row[key] = schema.converters[schema.attributes[key]].read(row[key]);
+                }
             });
             return row;
         };


### PR DESCRIPTION
For page-related information we would need to be able to add static columns to the schema. This PR adds this capability to Cassandra and SQLite.

For tests this PR depends on https://github.com/wikimedia/restbase-mod-table-spec/pull/14
Also, for get query ache dump, it depends on a bug fix in https://github.com/wikimedia/restbase-mod-table-sqlite/pull/16
Versions would be correctly updated when blocking PRs are resolved.
