### PR TITLE
Normalize stored schemas before hashing

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -79,6 +79,7 @@ DB.prototype._getSchema = function(tableName) {
     .then(function(res) {
         if (res && res.items.length) {
             var schema = JSON.parse(res.items[0].value);
+            schema = validator.validateAndNormalizeSchema(schema);
             return dbu.makeSchemaInfo(schema);
         } else {
             return null;


### PR DESCRIPTION
In 7fd61430a8cf50 the restbase-mod-table-spec module gained the ability to
sort index keys logically. When applied to new schemas only, this caused a
hash mis-match and thus an apparent schema change, which in turn caused
RESTBase to fail to start. Because of another issue in the service runner
logging code the reason for the start-up failure wasn't immediately clear (see
wikimedia/service-runner#46). With that patch applied,
the failure revealed itself as
https://gist.github.com/gwicke/0a4bd4a1e8635df2aa28.

This patch applies the schema normalization to both stored and new schemas,
which eliminates the cause of the hash mis-match. With this applied, RESTBase
starts up successfully in staging.

A similar patch for the cassandra backend is available in
https://github.com/wikimedia/restbase-mod-table-cassandra/pull/144.
