### PR TITLE
Added support for secondaryIndex removal

### DIFF
--- a/lib/SchemaMigrator.js
+++ b/lib/SchemaMigrator.js
@@ -188,19 +188,18 @@ function SecondaryIndexes(parentMigrator, current, proposed) {
 SecondaryIndexes.prototype.validate = function() {
     var self = this;
     if (self.addedIndexes.length > 0) {
-        throw new Error('Secondary index addition not supported');
+        throw new Error('Adding secondary indices is not supported');
     }
     if (self.changedIndexes.length > 0) {
-        throw new Error('Secondary index changing not supported');
+        throw new Error('Altering of secondary indices is not supported');
     }
 };
 
 SecondaryIndexes.prototype.migrate = function() {
     var self = this;
     return self.deletedIndexes.forEach(function(indexName) {
-        console.log('MIGRATE');
         self.log('warn/schemaMigration/secondaryIndexes', {
-            message: 'adding column' + indexName,
+            message: 'deleting secondary index ' + indexName,
             index: indexName
         });
         var sql = self._removeIndexTable(indexName);

--- a/lib/SchemaMigrator.js
+++ b/lib/SchemaMigrator.js
@@ -3,6 +3,7 @@
 var dbu = require('./dbutils');
 var P = require('bluebird');
 var util = require('util');
+var stringify = require('json-stable-stringify');
 
 
 /**
@@ -155,8 +156,68 @@ Index.prototype._hasSameIndex = function(indexes, proposedIndex) {
 };
 
 Index.prototype.migrate = function() {
+    // The migration is happening on individual attribute migration
 };
 
+/**
+ * Secondary index definition migrations
+ */
+function SecondaryIndexes(parentMigrator, current, proposed) {
+    var self = this;
+    self.client = parentMigrator.db.client;
+    self.log = parentMigrator.db.log;
+    self.conf = parentMigrator.db.conf;
+
+    self.table = parentMigrator.table;
+
+    self.addedIndexes = [];
+    self.deletedIndexes = [];
+    self.changedIndexes = [];
+
+    new Set(Object.keys(current).concat(Object.keys(proposed))).forEach(function(indexName) {
+        if (!proposed[indexName]) {
+            self.deletedIndexes.push(indexName);
+        } else if (!current[indexName]) {
+            self.addedIndexes.push(indexName);
+        } else if (!self._isEqual(current[indexName], proposed[indexName])) {
+            self.changedIndexes.push(indexName);
+        }
+    });
+}
+
+SecondaryIndexes.prototype.validate = function() {
+    var self = this;
+    if (self.addedIndexes.length > 0) {
+        throw new Error('Secondary index addition not supported');
+    }
+    if (self.changedIndexes.length > 0) {
+        throw new Error('Secondary index changing not supported');
+    }
+};
+
+SecondaryIndexes.prototype.migrate = function() {
+    var self = this;
+    return self.deletedIndexes.forEach(function(indexName) {
+        console.log('MIGRATE');
+        self.log('warn/schemaMigration/secondaryIndexes', {
+            message: 'adding column' + indexName,
+            index: indexName
+        });
+        var sql = self._removeIndexTable(indexName);
+        return self.client.run([{sql: sql}]);
+    });
+};
+
+SecondaryIndexes.prototype._isEqual = function(currentIndex, proposedIndex) {
+    return stringify(currentIndex) === stringify(proposedIndex);
+};
+
+SecondaryIndexes.prototype._removeIndexTable = function(indexName) {
+    var self = this;
+    // We can't drop columns from the joined secondary index table,
+    // so just delete an index over primary keys for this secondary index
+    return 'drop index if exists ' + dbu.indexOverSecIndexName(self.table, indexName);
+};
 
 /**
  * Version handling
@@ -186,6 +247,7 @@ var migrationHandlers = {
     table: Table,
     attributes: Attributes,
     index: Index,
+    secondaryIndexes: SecondaryIndexes,
     version: Version
 };
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -709,6 +709,10 @@ dbu.buildTableSql = function(schema, tableName) {
     return sql;
 };
 
+dbu.indexOverSecIndexName = function(tableName, indexName) {
+    return '[' + tableName + '_index_' + indexName + ']';
+};
+
 dbu.buildSecondaryIndexTableSql = function(schema, tableName) {
     var result = [];
     var secondaryIndexNames = Object.keys(schema.secondaryIndexes);
@@ -727,7 +731,7 @@ dbu.buildSecondaryIndexTableSql = function(schema, tableName) {
     // Next, create SQLite indexes over secondary index key columns for faster lookup
     Object.keys(schema.secondaryIndexes).forEach(function(indexName) {
         var indexSchema = schema.secondaryIndexes[indexName];
-        var indexSql = 'create index if not exists [' + tableName + '_index_' + indexName + ']';
+        var indexSql = 'create index if not exists ' + dbu.indexOverSecIndexName(tableName, indexName);
         indexSql += ' on [' + tableName + '_secondaryIndex] (';
         indexSql += getAllKeysOfTypes(indexSchema, ['hash', 'range']).map(dbu.fieldName).join(', ') + ')';
         result.push(indexSql);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
There was an idea to drop a by_ns secondary index, this adds support for secondary index removal in SQLite backend.

Bug: https://phabricator.wikimedia.org/T111959
