### PR TITLE
Allow database name to reference user directory

### DIFF
--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -6,6 +6,11 @@ var poolModule = require('generic-pool');
 
 P.promisifyAll(sqlite3, {suffix: '_p'});
 
+function expandDBName(options) {
+    var dbName = options.conf.dbname || 'sqlite.db';
+    return dbName.replace(/^~/, process.env.HOME || process.env.USERPROFILE);
+}
+
 function Wrapper(options) {
     var delay = options.conf.retry_delay || 100;
 
@@ -19,7 +24,7 @@ function Wrapper(options) {
     this.connectionPool = poolModule.Pool({
         name: 'sqlite',
         create: function(callback) {
-            var client = new sqlite3.Database(options.conf.dbname || 'restbase');
+            var client = new sqlite3.Database(expandDBName(options));
             callback(null, client);
         },
         destroy: function(client) {
@@ -30,7 +35,7 @@ function Wrapper(options) {
         log: options.log
     });
     P.promisifyAll(this.connectionPool, {suffix: '_p'});
-    this.readerConnection = new sqlite3.Database(options.conf.dbname || 'restbase');
+    this.readerConnection = new sqlite3.Database(expandDBName(options));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When testing restbase in docker with SQLite, it attempts to create a database file in working directory, however, working dir is owned by root, while tests are run under non-privileged user, so tests fail.

The easiest way to resolve it without making changes to docker scripts, is to create a testing db in user directory, however sqlite doesn't support `~/` notation. This PR adds such a feature.

Also, I've renamed the default DB name from `restbase`, as it's not a really good name here.
