### PR TITLE
Support binary data wrapped in JSON

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -10,7 +10,12 @@ var dbu = {};
 dbu.conversions = {
     json: {
         write: JSON.stringify,
-        read: JSON.parse,
+        read: function(body) {
+            return JSON.parse(body, function(key, value) {
+                return ((value instanceof Object) && (value.type === 'Buffer'))
+                    ? new Buffer(value.data) : value;
+            });
+        },
         type: 'blob'
     },
     string: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To store graphoid responses with binary PNG, we need to be able to wrap binary data (Buffer) into JSON. Perfect solution would be to support BSON across all of our tooling, however it's quite a big task, so for now lets use this workaround. 
