### PR TITLE
Support long type

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -90,7 +90,8 @@ dbu.conversions = {
         read: toString()
     },
     long: {
-        type: 'string'
+        type: 'string',
+        write: toString()
     }
 };
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -88,6 +88,9 @@ dbu.conversions = {
     },
     uuid: {
         read: toString()
+    },
+    long: {
+        type: 'string'
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds support for `long` type. In SQLite it's mapped to a string. Although internally SQLite supports integers up to 64bit, it's javascript driver doesn't support that. So, in case we try to store `long` as an integer, we might overflow on conversion. So, internally longs are compared as strings, which is proved to work (the test is added in a spec module). 

Although it's quite inefficient, there's no easy way to fix it, and it's not really important, as the primary purpose of using `long` is analytics use-case, so in production use of sqlite module we shouldn't see much use-cases of a `long` type.
