### PR TITLE
Support custom _ttl attributes for individual rows

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -305,6 +305,11 @@ DB.prototype._put = function(tableName, req) {
         req.attributes[schema.tid] = TimeUuid.now().toString();
     }
 
+    if (req.attributes._ttl) {
+        req.attributes._exist_until = new Date().getTime() + req.attributes._ttl * 1000;
+        delete req.attributes._ttl;
+    }
+
     req.timestamp = TimeUuid.fromString(req.attributes[schema.tid].toString()).getDate();
     var query = dbu.buildPutQuery(req, tableName, schema);
     var queries = [ query.data ];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "sqlite3": "^3.1.0",
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.0",
+    "restbase-mod-table-spec": "^0.1.1",
     "generic-pool": "^2.2.0",
     "lru-cache": "^2.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sqlite3": "^3.1.0",
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.1",
+    "restbase-mod-table-spec": "^0.1.2",
     "generic-pool": "^2.2.0",
     "lru-cache": "^2.7.0"
   },


### PR DESCRIPTION
In SQLite the `_ttl` is stored a `_exists_until` for speedup on selects, so we just rewrite a `_ttl` attribute to the `_exists_until` attribute.
