### PR TITLE
JSCS: Ignore the else-after-return error

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -17,7 +17,8 @@
   "requireTrailingComma": null,
   "disallowTrailingComma": null,
   "requireSpacesInsideObjectBrackets": "all",
-
+  "requireEarlyReturn": false,
+  
   "excludeFiles": [
     "node_modules/**",
     "test/**",


### PR DESCRIPTION
Obvious issue: the new JSCS added a new rule we don't follow, so ignore it, same as in all of other modules we run jscs on
