### PR TITLE
Updated to bluebird 3

### DIFF
--- a/lib/clientWrapper.js
+++ b/lib/clientWrapper.js
@@ -140,7 +140,7 @@ Wrapper.prototype.all = function(query, params) {
 };
 
 Wrapper.prototype.prepare = function(query) {
-    return P.promisifyAll(this.readerConnection.prepare(query), { suffix: '_p' });
+    return this.readerConnection.prepare(query);
 };
 
 module.exports = Wrapper;

--- a/package.json
+++ b/package.json
@@ -22,22 +22,22 @@
   },
   "homepage": "https://github.com/wikimedia/restbase-mod-table-sqlite",
   "dependencies": {
-    "bluebird": "^3.0.6",
+    "bluebird": "^3.1.1",
     "extend": "^3.0.0",
-    "js-yaml": "^3.4.6",
+    "js-yaml": "^3.5.2",
     "sqlite3": "^3.1.1",
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.3",
-    "generic-pool": "^2.2.1",
-    "lru-cache": "^3.2.0"
+    "restbase-mod-table-spec": "^0.1.6",
+    "generic-pool": "^2.3.1",
+    "lru-cache": "^4.0.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.4",
-    "istanbul": "^0.4.1",
+    "coveralls": "^2.11.6",
+    "istanbul": "^0.4.2",
     "mocha-lcov-reporter": "^1.0.0",
     "mocha": "^2.3.4",
-    "mocha-jshint": "^2.2.5",
+    "mocha-jshint": "^2.2.6",
     "mocha-jscs": "^4.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/wikimedia/restbase-mod-table-sqlite",
   "dependencies": {
-    "bluebird": "~2.8.2",
+    "bluebird": "^3.0.6",
     "extend": "^3.0.0",
     "js-yaml": "^3.4.6",
     "sqlite3": "^3.1.1",


### PR DESCRIPTION
- Updated to bluebird 3
- Updated dependencies
- Fixed a bug: For prepared requests we don't need to repromisify the resulting preparedStatement object, it's already promisified

Depends on https://github.com/wikimedia/restbase-mod-table-spec/pull/31 being merged and published.
