### PR TITLE
Bug fix: Put should have upsert semantics and not insert or replace

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -313,11 +313,7 @@ DB.prototype._put = function(tableName, req) {
     }
 
     req.timestamp = TimeUuid.fromString(req.attributes[schema.tid].toString()).getDate();
-    var query = dbu.buildPutQuery(req, tableName, schema);
-    var queries = [ query.data ];
-    if (query.static) {
-        queries.push(query.static);
-    }
+    var queries = dbu.buildPutQuery(req, tableName, schema);
     dbu.buildSecondaryIndexUpdateQuery(req, tableName, schema).forEach(function(query) {
         queries.push(query);
     });
@@ -365,8 +361,9 @@ DB.prototype._revisionPolicyUpdate = function(tableName, query, schema) {
                     attributes: item
                 };
                 updateQuery.attributes._exist_until = expireTime;
-                return dbu.buildPutQuery(updateQuery, tableName, schema).data;
+                return dbu.buildPutQuery(updateQuery, tableName, schema, true);
             }))
+            .reduce(function(accumulator, item) { return accumulator.concat(item); }, [])
             .then(function(queries) {
                 queries.push(dbu.buildDeleteExpiredQuery(schema, tableName));
                 return self.client.run(queries);

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -482,11 +482,9 @@ function buildUpdateQuery(req, tableName, schema, dataKVMap, primaryKeyKVMap, ig
     var dataParams = [];
     var condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema, false, true);
     var sql = (ignore ? 'update or ignore ' : 'update ') + '[' + tableName + '_data] set ';
-    sql += Object.keys(dataKVMap)
-    .filter(function(column) {
+    sql += Object.keys(dataKVMap).filter(function(column) {
         return schema.iKeys.indexOf(column) < 0;
-    })
-    .map(function(column) {
+    }).map(function(column) {
         dataParams.push(dataKVMap[column]);
         return dbu.fieldName(column) + '= ?';
     }).join(',');

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -478,7 +478,49 @@ dbu.extractGetParams = function(query, schema, includePreparedForDelete) {
     return params;
 };
 
-dbu.buildPutQuery = function(req, tableName, schema) {
+function buildUpdateQuery(req, tableName, schema, dataKVMap, primaryKeyKVMap, ignore) {
+    var dataParams = [];
+    var condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema, false, true);
+    var sql = (ignore ? 'update or ignore ' : 'update ') + '[' + tableName + '_data] set ';
+    sql += Object.keys(dataKVMap)
+    .filter(function(column) {
+        return schema.iKeys.indexOf(column) < 0;
+    })
+    .map(function(column) {
+        dataParams.push(dataKVMap[column]);
+        return dbu.fieldName(column) + '= ?';
+    }).join(',');
+    sql += ' where ' + condition.query;
+    dataParams = dataParams.concat(condition.params);
+    return {
+        sql: sql,
+        params: dataParams
+    };
+}
+
+function buildInsertQuery(tableName, dataKVMap) {
+    var sql;
+    var dataParams = [];
+    var keyList = Object.keys(dataKVMap);
+    var proj = keyList.map(dbu.fieldName).join(',');
+
+    sql = 'insert or ignore ';
+    sql += 'into [' + tableName + '_data] (' + proj + ') values (';
+    sql += Array.apply(null, new Array(keyList.length)).map(function() {
+        return '?';
+    }).join(', ') + ')';
+
+    Object.keys(dataKVMap).forEach(function(key) {
+        dataParams.push(dataKVMap[key]);
+    });
+
+    return {
+        sql: sql,
+        params: dataParams
+    };
+}
+
+dbu.buildPutQuery = function(req, tableName, schema, ignoreStatic) {
     var dataKVMap = {};
     var staticKVMap = {};
     var primaryKeyKVMap = {};
@@ -520,64 +562,36 @@ dbu.buildPutQuery = function(req, tableName, schema) {
         req.if = req.if.trim().split(/\s+/).join(' ').toLowerCase();
     }
 
-    var staticSql;
-    var sql;
-    var dataParams = [];
+    var queries = [];
 
     if (req.if instanceof Object) {
-        var condition = buildCondition(Object.assign(primaryKeyKVMap, req.if), schema, false, true);
-        sql = 'update [' + tableName + '_data] set ';
-        sql += Object.keys(dataKVMap)
-        .filter(function(column) {
-            return schema.iKeys.indexOf(column) < 0;
-        })
-        .map(function(column) {
-            dataParams.push(dataKVMap[column]);
-            return dbu.fieldName(column) + '= ?';
-        }).join(',');
-        sql += ' where ' + condition.query;
-        dataParams = dataParams.concat(condition.params);
+        queries.push(buildUpdateQuery(req, tableName, schema, dataKVMap, primaryKeyKVMap));
+    } else if (req.if === 'not exists') {
+        queries.push(buildInsertQuery(tableName, dataKVMap));
     } else {
-        var keyList = Object.keys(dataKVMap);
-        var proj = keyList.map(dbu.fieldName).join(',');
-        if (req.if === 'not exists') {
-            sql = 'insert or ignore ';
-        } else {
-            sql = 'insert or replace ';
+        if (Object.keys(dataKVMap).length > Object.keys(primaryKeyKVMap).length) {
+            queries.push(buildUpdateQuery(req, tableName, schema,
+                dataKVMap, primaryKeyKVMap, true));
         }
-        sql += 'into [' + tableName + '_data] (' + proj + ') values (';
-        sql += Array.apply(null, new Array(keyList.length)).map(function() {
-            return '?';
-        }).join(', ') + ')';
-
-        Object.keys(dataKVMap).map(function(key) {
-            dataParams.push(dataKVMap[key]);
-        });
+        queries.push(buildInsertQuery(tableName, dataKVMap));
     }
 
-    if (staticNeeded) {
-        staticSql = 'insert or replace into [' + tableName + '_static] ('
+    if (staticNeeded && !ignoreStatic) {
+        var staticSql = 'insert or replace into [' + tableName + '_static] ('
             + Object.keys(staticKVMap).map(dbu.fieldName).join(', ')
             + ') values ('
             + Object.keys(staticKVMap).map(function() {
                 return '?';
             }).join(', ') + ')';
-    }
-    var result = {
-        data: {
-            sql: sql,
-            params: dataParams
-        }
-    };
-    if (staticNeeded) {
-        result.static = {
+        var staticData = Object.keys(staticKVMap).map(function(key) {
+            return staticKVMap[key];
+        });
+        queries.push({
             sql: staticSql,
-            params: Object.keys(staticKVMap).map(function(key) {
-                return staticKVMap[key];
-            })
-        };
+            params: staticData
+        });
     }
-    return result;
+    return queries;
 };
 
 dbu.buildSecondaryIndexUpdateQuery = function(req, tableName, schema) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "sqlite3": "^3.1.1",
     "cassandra-uuid": "^0.0.2",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.6",
+    "restbase-mod-table-spec": "^0.1.7",
     "generic-pool": "^2.3.1",
     "lru-cache": "^4.0.0"
   },


### PR DESCRIPTION
I've noticed a bug in SQLite module: when we put something, the semantics should be `insert or update`, but we've been using `insert or replace`. Sadly, SQLite doesn't support `insert or update` out of the box, which means we need to emulate it. The best way to do that is to run 2 queries: `UPDATE OR IGNORE` followed by `INSERT OR IGNORE`. Only one of the queries will be executed, giving us proper semantics.

cc @wikimedia/services 
