### PR TITLE
Allow the key to be set to 0

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -199,7 +199,7 @@ dbu.hashKey = function hashKey(key) {
     .digest()
     .toString('base64')
         // Replace [+/] from base64 with _ (illegal in Cassandra)
-    .replace(/[+\/]/g, '_')
+    .replace(/[+/]/g, '_')
         // Remove base64 padding, has no entropy
     .replace(/=+$/, '');
 };
@@ -575,7 +575,10 @@ dbu.buildPutQuery = (req, tableName, schema, ignoreStatic) => {
     const primaryKeyKVMap = {};
 
     schema.iKeys.forEach((key) => {
-        if (req.attributes[key] && (schema.iKeys.indexOf(key) >= 0)) {
+        const value = req.attributes[key];
+        if (value !== undefined
+                && value !== null
+                && (schema.iKeys.indexOf(key) >= 0)) {
             primaryKeyKVMap[key] = req.attributes[key];
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When writing we use the following algorithm to avoid the lack of `upsert` in SQLite:
1. Since we don't know if the row with the same keys are there, we first try to `update` the row with new values. If it's not there this command will be ignored.
2. We `insert or ignore` the update - if it was there nothing will happen and the value would be set but previous query, if it wasn't there, new row will be inserted. 

However, in case all non-key properties are not set (like when we're updating only the static column which lives in a separate table) we don't need to execute the first `update` query. To figure this out we create a `primaryKeyKVMap` which maps all primary keys to it's values and then compare if this map is smaller then the complete `dataKVMap`. 

However, in case some of the primary keys was falsy like`0`, it was excluded from the `parimaryKVMap` forsing us to wronly execute the `update` query which let to an SQL syntax error.

cc @wikimedia/services 