### PR TITLE
Optimise the TTL revision retention policy

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -288,6 +288,12 @@ class DB {
         }
 
         req.timestamp = TimeUuid.fromString(req.attributes[schema.tid].toString()).getDate();
+        if (schema.revisionRetentionPolicy
+                && schema.revisionRetentionPolicy.type === 'latest'
+                && schema.revisionRetentionPolicy.count === 0) {
+            req.attributes._exist_until = new Date().getTime()
+                + schema.revisionRetentionPolicy.grace_ttl * 1000;
+        }
         const queries = dbu.buildPutQuery(req, tableName, schema);
         dbu.buildSecondaryIndexUpdateQuery(req, tableName, schema).forEach((query) => {
             queries.push(query);
@@ -336,7 +342,10 @@ class DB {
     }
 
     _revisionPolicyUpdate(tableName, query, schema) {
-        if (!schema.revisionRetentionPolicy || schema.revisionRetentionPolicy.type === 'all') {
+        if (!schema.revisionRetentionPolicy
+                || schema.revisionRetentionPolicy.type === 'all'
+                || (schema.revisionRetentionPolicy.type === 'latest'
+                    && schema.revisionRetentionPolicy.count === 0)) {
             return P.resolve();
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For the TTL policy we can avoid doing 'write -> read -> update' pattern because we always know that the TTL will be set, so we can skip the normal revision policy update and write with TTL right away.

Bug: https://phabricator.wikimedia.org/T150703