### PR TITLE
Replace `json-stable-stringify` with `fast-json-stable-stringify`

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -6,7 +6,7 @@ const SchemaMigrator = require('./SchemaMigrator');
 const Wrapper = require('./clientWrapper');
 const LRU = require('lru-cache');
 const validator = require('restbase-mod-table-spec').validator;
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 
 class DB {
     constructor(options) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -2,7 +2,7 @@
 
 const extend = require('extend');
 const crypto = require('crypto');
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 const TimeUuid = require('cassandra-uuid').TimeUuid;
 
 const dbu = {};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-sqlite",
   "description": "RESTBase table storage using sqlite for testing purposes",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -23,14 +23,14 @@
   "homepage": "https://github.com/wikimedia/restbase-mod-table-sqlite",
   "dependencies": {
     "bluebird": "^3.5.2",
-    "extend": "^3.0.2",
-    "js-yaml": "^3.12.0",
-    "sqlite3": "^4.0.3",
     "cassandra-uuid": "^0.1.0",
-    "json-stable-stringify": "^1.0.1",
-    "restbase-mod-table-spec": "^1.1.2",
+    "extend": "^3.0.2",
+    "fast-json-stable-stringify": "^2.0.0",
     "generic-pool": "^3.4.2",
-    "lru-cache": "^4.1.3"
+    "js-yaml": "^3.12.0",
+    "lru-cache": "^4.1.3",
+    "restbase-mod-table-spec": "^1.1.2",
+    "sqlite3": "^4.0.3"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",


### PR DESCRIPTION
fast-json-stable-stringify is being used because it does not have any dependencies and has been shown to be faster than json-stable-stringify

Bug: [T210426](https://phabricator.wikimedia.org/T210426)