### PR TITLE
Removed cassandra-uuid dependency

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -3,9 +3,9 @@
 const extend = require('extend');
 const crypto = require('crypto');
 const stringify = require('fast-json-stable-stringify');
-const TimeUuid = require('cassandra-uuid').TimeUuid;
 
 const dbu = {};
+const uuidV1Test = (uuid) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(uuid);
 
 // Conversion factories. We create a function for each type so that it can be
 // compiled monomorphically.
@@ -83,7 +83,7 @@ dbu.conversions = {
         },
         write(value) {
             if (value) {
-                if (!TimeUuid.test(value)) {
+                if (!uuidV1Test(value)) {
                     throw new Error(`Illegal uuid value ${value}`);
                 }
                 value = value.substr(15, 3) +

--- a/package.json
+++ b/package.json
@@ -23,13 +23,12 @@
   "homepage": "https://github.com/wikimedia/restbase-mod-table-sqlite",
   "dependencies": {
     "bluebird": "^3.5.2",
-    "cassandra-uuid": "^0.1.0",
     "extend": "^3.0.2",
     "fast-json-stable-stringify": "^2.0.0",
     "generic-pool": "^3.4.2",
     "js-yaml": "^3.12.0",
     "lru-cache": "^4.1.3",
-    "restbase-mod-table-spec": "^1.1.2",
+    "restbase-mod-table-spec": "^1.1.3",
     "sqlite3": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The only method used from cassandra-uuid was the test function to validate UUIDs. Added validation method locally and removed the uuid dependency altogether.

Note: I changed the restbase-mod-table-spec dependency to 1.1.3 which would need to be merged first.

Bug: T223690